### PR TITLE
Add tests for ContentLock service and SignalR hub

### DIFF
--- a/ContentLock.Tests/ContentLock.Tests.csproj
+++ b/ContentLock.Tests/ContentLock.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ContentLock\ContentLock.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ContentLock.Tests/ContentLockHubTests.cs
+++ b/ContentLock.Tests/ContentLockHubTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using Xunit;
+using ContentLock.Interfaces;
+using ContentLock.SignalR;
+using ContentLock.Models.Backoffice;
+
+namespace ContentLock.Tests
+{
+    public class ContentLockHubTests
+    {
+        private readonly Mock<IContentLockService> _contentLockServiceMock;
+        private readonly Mock<IHubCallerClients<IContentLockHubEvents>> _clientsMock;
+        private readonly Mock<IContentLockHubEvents> _clientProxyMock;
+        private readonly ContentLockHub _hub;
+
+        public ContentLockHubTests()
+        {
+            _contentLockServiceMock = new Mock<IContentLockService>();
+            _clientsMock = new Mock<IHubCallerClients<IContentLockHubEvents>>();
+            _clientProxyMock = new Mock<IContentLockHubEvents>();
+
+            _clientsMock.Setup(clients => clients.Caller).Returns(_clientProxyMock.Object);
+
+            _hub = new ContentLockHub(_contentLockServiceMock.Object)
+            {
+                Clients = _clientsMock.Object
+            };
+        }
+
+        [Fact]
+        public async Task TestOnConnectedAsync()
+        {
+            // Arrange
+            var contentLocks = new List<ContentLockOverviewItem>
+            {
+                new ContentLockOverviewItem
+                {
+                    Key = Guid.NewGuid(),
+                    NodeName = "Test Node",
+                    ContentType = "Test Type",
+                    CheckedOutBy = "Test User",
+                    CheckedOutByKey = Guid.NewGuid(),
+                    LastEdited = DateTime.Now,
+                    LockedAtDate = DateTime.Now
+                }
+            };
+
+            _contentLockServiceMock.Setup(service => service.GetLockOverviewAsync())
+                .ReturnsAsync(new ContentLockOverview { Items = contentLocks });
+
+            // Act
+            await _hub.OnConnectedAsync();
+
+            // Assert
+            _clientProxyMock.Verify(client => client.ReceiveLatestContentLocks(contentLocks), Times.Once);
+        }
+
+        [Fact]
+        public async Task TestOnDisconnectedAsync()
+        {
+            // Act
+            await _hub.OnDisconnectedAsync(null);
+
+            // Assert
+            // No specific assertions for now, just ensuring no exceptions are thrown
+        }
+
+        [Fact]
+        public async Task TestGetLatestLockInfoForNewConnection()
+        {
+            // Arrange
+            var contentLocks = new List<ContentLockOverviewItem>
+            {
+                new ContentLockOverviewItem
+                {
+                    Key = Guid.NewGuid(),
+                    NodeName = "Test Node",
+                    ContentType = "Test Type",
+                    CheckedOutBy = "Test User",
+                    CheckedOutByKey = Guid.NewGuid(),
+                    LastEdited = DateTime.Now,
+                    LockedAtDate = DateTime.Now
+                }
+            };
+
+            _contentLockServiceMock.Setup(service => service.GetLockOverviewAsync())
+                .ReturnsAsync(new ContentLockOverview { Items = contentLocks });
+
+            // Act
+            await _hub.GetType().GetMethod("GetLatestLockInfoForNewConnection", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .Invoke(_hub, null);
+
+            // Assert
+            _clientProxyMock.Verify(client => client.ReceiveLatestContentLocks(contentLocks), Times.Once);
+        }
+
+        [Fact]
+        public async Task TestReceiveLatestContentLocks()
+        {
+            // Arrange
+            var contentLocks = new List<ContentLockOverviewItem>
+            {
+                new ContentLockOverviewItem
+                {
+                    Key = Guid.NewGuid(),
+                    NodeName = "Test Node",
+                    ContentType = "Test Type",
+                    CheckedOutBy = "Test User",
+                    CheckedOutByKey = Guid.NewGuid(),
+                    LastEdited = DateTime.Now,
+                    LockedAtDate = DateTime.Now
+                }
+            };
+
+            // Act
+            await _hub.Clients.Caller.ReceiveLatestContentLocks(contentLocks);
+
+            // Assert
+            _clientProxyMock.Verify(client => client.ReceiveLatestContentLocks(contentLocks), Times.Once);
+        }
+    }
+}

--- a/ContentLock.Tests/ContentLockServiceTests.cs
+++ b/ContentLock.Tests/ContentLockServiceTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ContentLock.Interfaces;
+using ContentLock.Models.Backoffice;
+using ContentLock.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Xunit;
+
+namespace ContentLock.Tests
+{
+    public class ContentLockServiceTests
+    {
+        private readonly Mock<ILogger<ContentLockService>> _loggerMock;
+        private readonly Mock<IScopeProvider> _scopeProviderMock;
+        private readonly Mock<IUserService> _userServiceMock;
+        private readonly Mock<IPublishedContentQuery> _publishedContentQueryMock;
+        private readonly Mock<IAuditService> _auditServiceMock;
+        private readonly Mock<IUserIdKeyResolver> _userIdKeyResolverMock;
+        private readonly Mock<IIdKeyMap> _idKeyMapMock;
+        private readonly ContentLockService _contentLockService;
+
+        public ContentLockServiceTests()
+        {
+            _loggerMock = new Mock<ILogger<ContentLockService>>();
+            _scopeProviderMock = new Mock<IScopeProvider>();
+            _userServiceMock = new Mock<IUserService>();
+            _publishedContentQueryMock = new Mock<IPublishedContentQuery>();
+            _auditServiceMock = new Mock<IAuditService>();
+            _userIdKeyResolverMock = new Mock<IUserIdKeyResolver>();
+            _idKeyMapMock = new Mock<IIdKeyMap>();
+
+            _contentLockService = new ContentLockService(
+                _loggerMock.Object,
+                _scopeProviderMock.Object,
+                _userServiceMock.Object,
+                _publishedContentQueryMock.Object,
+                _auditServiceMock.Object,
+                _userIdKeyResolverMock.Object,
+                _idKeyMapMock.Object
+            );
+        }
+
+        [Fact]
+        public async Task TestLockContentAsync()
+        {
+            // Arrange
+            var contentKey = Guid.NewGuid();
+            var userKey = Guid.NewGuid();
+            var contentNodeMock = new Mock<IPublishedContent>();
+            contentNodeMock.Setup(c => c.Name).Returns("Test Node");
+            contentNodeMock.Setup(c => c.ContentType.Alias).Returns("TestType");
+            contentNodeMock.Setup(c => c.UpdateDate).Returns(DateTime.Now);
+
+            _publishedContentQueryMock.Setup(p => p.Content(contentKey)).Returns(contentNodeMock.Object);
+            _userServiceMock.Setup(u => u.GetAsync(userKey)).ReturnsAsync(new User { Name = "Test User" });
+
+            // Act
+            var result = await _contentLockService.LockContentAsync(contentKey, userKey);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(contentKey, result.Key);
+            Assert.Equal("Test Node", result.NodeName);
+            Assert.Equal("TestType", result.ContentType);
+            Assert.Equal("Test User", result.CheckedOutBy);
+            Assert.Equal(userKey, result.CheckedOutByKey);
+        }
+
+        [Fact]
+        public async Task TestUnlockContentAsync()
+        {
+            // Arrange
+            var contentKey = Guid.NewGuid();
+            var userKey = Guid.NewGuid();
+
+            // Act
+            await _contentLockService.UnlockContentAsync(contentKey, userKey);
+
+            // Assert
+            _scopeProviderMock.Verify(s => s.CreateScope(It.IsAny<bool>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task TestGetLockInfoAsync()
+        {
+            // Arrange
+            var contentKey = Guid.NewGuid();
+            var userKey = Guid.NewGuid();
+            var contentLocks = new ContentLocks
+            {
+                ContentKey = contentKey,
+                UserKey = userKey,
+                LockedAtDate = DateTime.Now
+            };
+
+            _scopeProviderMock.Setup(s => s.CreateScope(It.IsAny<bool>())).Returns(new Mock<IScope>().Object);
+            _userServiceMock.Setup(u => u.GetAsync(userKey)).ReturnsAsync(new User { Name = "Test User" });
+
+            // Act
+            var result = await _contentLockService.GetLockInfoAsync(contentKey, userKey);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.IsLocked);
+            Assert.Equal(userKey, result.LockedByKey);
+            Assert.Equal("Test User", result.LockedByName);
+        }
+
+        [Fact]
+        public async Task TestGetLockOverviewAsync()
+        {
+            // Arrange
+            var contentLocks = new List<ContentLocks>
+            {
+                new ContentLocks
+                {
+                    ContentKey = Guid.NewGuid(),
+                    UserKey = Guid.NewGuid(),
+                    LockedAtDate = DateTime.Now
+                }
+            };
+
+            _scopeProviderMock.Setup(s => s.CreateScope(It.IsAny<bool>())).Returns(new Mock<IScope>().Object);
+            _userServiceMock.Setup(u => u.GetAsync(It.IsAny<Guid>())).ReturnsAsync(new User { Name = "Test User" });
+
+            // Act
+            var result = await _contentLockService.GetLockOverviewAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(contentLocks.Count, result.TotalResults);
+        }
+    }
+}


### PR DESCRIPTION
Add tests for the ContentLock service and SignalR hub.

* **ContentLockServiceTests.cs**
  - Add tests for `LockContentAsync`, `UnlockContentAsync`, `GetLockInfoAsync`, and `GetLockOverviewAsync` methods.
  - Use Moq to mock dependencies and Xunit for assertions.

* **ContentLockHubTests.cs**
  - Add tests for `OnConnectedAsync`, `OnDisconnectedAsync`, `GetLatestLockInfoForNewConnection`, and `ReceiveLatestContentLocks` methods.
  - Use Moq to mock dependencies and Xunit for assertions.

* **ContentLock.Tests.csproj**
  - Add a new test project with necessary dependencies (Moq, Xunit).
  - Add a project reference to the main `ContentLock` project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/warrenbuckley/Umbraco.Community.ContentLock/pull/6?shareId=de92ea1b-6cd2-4524-9121-67bbb7798c6d).