### PR TITLE
Add Welsh translations

### DIFF
--- a/ContentLock/Client/src/localizations/cy.ts
+++ b/ContentLock/Client/src/localizations/cy.ts
@@ -1,0 +1,33 @@
+﻿export default {
+    contentLockDashboard: {
+        label: 'Clo Cynnwys',
+        pageNameHeader: 'Enw\'r Dudalen',
+        contentTypeHeader: 'Math o Gynnwys',
+        checkedOutByHeader: 'Wedi\'i Wirio Allan Gan',
+        checkedOutAtHeader: 'Wedi\'i Wirio Allan Ar',
+        lastEditedHeader: 'Golygiad Diwethaf',
+        unlockAction: 'Datgloi',
+        pagesCheckedOutTitle: 'Tudalennau wedi\'u Gwirio Allan',
+    },
+    contentLockFooterApp: {
+        lockedByYou: 'Mae\'r dudalen hon wedi\'i chloi gennych chi',
+        lockedByAnother: 'Mae\'r dudalen hon wedi\'i chloi gan {0}',
+    },
+    contentLockNotification: {
+        lockedHeader: 'Cynnwys wedi\'i Gloi',
+        lockedMessage: 'Mae\'r ddogfen wedi\'i chloi er mwyn i chi ei golygu.',
+        unlockedHeader: 'Cynnwys wedi\'i Ddatgloi',
+        unlockedMessage: 'Mae\'r ddogfen wedi\'i datgloi i ganiatáu i ddefnyddwyr eraill ei golygu.',
+        bulkUnlockHeader: 'Cynnwys wedi\'i Ddatgloi',
+        bulkUnlockMessage: 'Mae\'r cynnwys a ddewiswyd wedi\'i ddatgloi\'n llwyddiannus',
+    },
+    contentLockPermission: {
+        group: 'Clo Cynnwys', // TODO: Currently not used in Umbraco but added for future use
+        label: 'Datglöwr',
+        description: 'Yn caniatáu i\'r grŵp o ddefnyddwyr ddatgloi dogfen sydd wedi\'i chloi gan ddefnyddiwr arall.',
+    },
+    contentLockUsersModal: {
+        modalHeader: 'Pwy sy\'n ar-lein?',
+        listOfUsers: 'Defnyddwyr Ar-lein'
+    }
+};

--- a/ContentLock/Client/src/localizations/cy.ts
+++ b/ContentLock/Client/src/localizations/cy.ts
@@ -22,8 +22,8 @@
         bulkUnlockMessage: 'Mae\'r cynnwys a ddewiswyd wedi\'i ddatgloi\'n llwyddiannus',
     },
     contentLockPermission: {
-        group: 'Clo Cynnwys', // TODO: Currently not used in Umbraco but added for future use
-        label: 'Datglöwr',
+        group: 'Content Lock', // TODO: Currently not used in Umbraco but added for future use
+        label: 'Unlocker',
         description: 'Yn caniatáu i\'r grŵp o ddefnyddwyr ddatgloi dogfen sydd wedi\'i chloi gan ddefnyddiwr arall.',
     },
     contentLockUsersModal: {

--- a/ContentLock/Client/src/localizations/manifest.ts
+++ b/ContentLock/Client/src/localizations/manifest.ts
@@ -44,4 +44,13 @@ export const manifests: Array<UmbExtensionManifest> = [
             culture: 'it-IT',
         }
     },
+    {
+        alias: 'contentlock.localization.cy',
+        name: 'Cymraeg',
+        type: 'localization',
+        js: () => import('./cy'),
+        meta: {
+            culture: 'cy-GB',
+        }
+    }
 ]


### PR DESCRIPTION
Add Welsh translations.

Set culture code to `cy-GB` to match the culture code used for the Welsh translations in the Umbraco backoffice.
https://github.com/umbraco/Umbraco-CMS/blob/contrib/src/Umbraco.Web.UI.Client/src/assets/lang/cy-gb.ts