### PR TITLE
Bugfix/multiple signalr connections for same user

### DIFF
--- a/ContentLock/Client/src/conditions/CanShowCommonActions.Condition.ts
+++ b/ContentLock/Client/src/conditions/CanShowCommonActions.Condition.ts
@@ -33,12 +33,12 @@ export default class CanShowCommonActionsCondition extends UmbConditionBase<UmbC
 
         this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT, (signalrCtx) => {
             if(!this.#unique) {
-                console.error('Unique identifier of document is not available for SignalR context');
+                console.warn('Unique identifier of document is not available for SignalR context');
                 return;
             }
 
             if(!this.#currentUserUnique) {
-                console.error('Current User Unique identifier is not available for SignalR context');
+                console.warn('Current User Unique identifier is not available for SignalR context');
                 return;
             }
 

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -125,8 +125,8 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
                 this.#contentLocks.remove(contentKeys);
             });
 
-            this.signalrConnection.on('UserConnected', (connectedUserKey:string, connectedUserName:string) => {
-                this.#connectedBackofficeUsers.appendOne({ userKey: connectedUserKey, userName: connectedUserName });
+            this.signalrConnection.on('UserConnected', (connectedUserKey:string) => {
+                this.#connectedBackofficeUsers.appendOne({ userKey: connectedUserKey });
 
                 this.observe(observeMultiple([this.EnableSounds, this.LoginSound]), ([enableSounds, loginSound]) => {
                     if(enableSounds){
@@ -155,6 +155,7 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
 
             this.signalrConnection.on('ReceiveListOfConnectedUsers', (connectedUsers:{ [key: string]: string }) => {
                 // Convert the object into an array of { userKey, userName }
+                // TODO only receive array of guids
                 const usersArray = Object.entries(connectedUsers).map(([userKey, userName]) => ({
                     userKey,
                     userName,

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -5,7 +5,6 @@ import { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
 import { UMB_AUTH_CONTEXT } from "@umbraco-cms/backoffice/auth";
 import { ContentLockOverviewItem } from "../api";
 import { observeMultiple, UmbArrayState, UmbObjectState } from "@umbraco-cms/backoffice/observable-api";
-import { ConnectedBackofficeUsers } from "../interfaces/ConnectedBackofficeUsers";
 import { ContentLockOptions } from "../interfaces/ContentLockOptions";
 
 export default class ContentLockSignalrContext extends UmbContextBase<ContentLockSignalrContext>
@@ -21,7 +20,7 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
     #contentLocks = new UmbArrayState<ContentLockOverviewItem>([], (item) => item.key);
     
     // Used to store the overview of locks
-    #connectedBackofficeUsers = new UmbArrayState<ConnectedBackofficeUsers>([], (item) => item.userKey);
+    #connectedBackofficeUserKeys = new UmbArrayState<string>([], (item) => item);
 
     // Used to store the options for the content lock package
     // Sets the default values for the options
@@ -44,10 +43,10 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
     public totalContentLocks = this.#contentLocks.asObservablePart(data => data.length);
 
     // All of the connected users to the backoffice as an observable array of ConnectedBackofficeUsers objects
-    public connectedUsers = this.#connectedBackofficeUsers.asObservable();
+    public connectedUserKeys = this.#connectedBackofficeUserKeys.asObservable();
 
     // The total number of connected users to the backoffice as an observable number
-    public totalConnectedUsers = this.#connectedBackofficeUsers.asObservablePart(users => users.length);
+    public totalConnectedUsers = this.#connectedBackofficeUserKeys.asObservablePart(users => users.length);
 
     /**
      * The total number of connected users to the backoffice as an observable number
@@ -55,8 +54,8 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
      * @param currentUserKey - The key of the current user to exclude from the count
      */
     public totalConnectedOtherUsers(currentUserKey:string){
-        return this.#connectedBackofficeUsers.asObservablePart((users) => {
-            const otherUsers = users.filter(user => user.userKey !== currentUserKey);
+        return this.#connectedBackofficeUserKeys.asObservablePart((users) => {
+            const otherUsers = users.filter(userKey => userKey !== currentUserKey);
             return otherUsers.length;
         });
     };
@@ -126,7 +125,7 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
             });
 
             this.signalrConnection.on('UserConnected', (connectedUserKey:string) => {
-                this.#connectedBackofficeUsers.appendOne({ userKey: connectedUserKey });
+                this.#connectedBackofficeUserKeys.appendOne(connectedUserKey);
 
                 this.observe(observeMultiple([this.EnableSounds, this.LoginSound]), ([enableSounds, loginSound]) => {
                     if(enableSounds){
@@ -140,7 +139,7 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
             });
 
             this.signalrConnection.on('UserDisconnected', (connectedUserKey:string) => {
-                this.#connectedBackofficeUsers.removeOne(connectedUserKey);
+                this.#connectedBackofficeUserKeys.removeOne(connectedUserKey);
 
                 this.observe(observeMultiple([this.EnableSounds, this.LogoutSound]), ([enableSounds, logoutSound]) => {
                     if(enableSounds){
@@ -153,16 +152,12 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
                 });
             });
 
-            this.signalrConnection.on('ReceiveListOfConnectedUsers', (connectedUsers:{ [key: string]: string }) => {
-                // Convert the object into an array of { userKey, userName }
-                // TODO only receive array of guids
-                const usersArray = Object.entries(connectedUsers).map(([userKey, userName]) => ({
-                    userKey,
-                    userName,
-                }));
+            this.signalrConnection.on('ReceiveListOfConnectedUsers', (connectedUsers:string[]) => {
+
+                console.log('RECEIVED ListOfConnectedUsers', connectedUsers);
 
                 // Update the observable state with the new list of users
-                this.#connectedBackofficeUsers.setValue(usersArray);
+                this.#connectedBackofficeUserKeys.setValue(connectedUsers);
             });
 
             this.signalrConnection.on('ReceiveLatestOptions', (options:ContentLockOptions) =>{

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -78,7 +78,7 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
         // Need auth context to use the token to pass to SignalR hub
         this.consumeContext(UMB_AUTH_CONTEXT, async (authCtx) => {
             if (!authCtx) {
-                console.error('Auth context is not available for SignalR connection');
+                console.warn('Auth context is not available for SignalR connection');
                 return;
             }
 
@@ -153,9 +153,6 @@ export default class ContentLockSignalrContext extends UmbContextBase<ContentLoc
             });
 
             this.signalrConnection.on('ReceiveListOfConnectedUsers', (connectedUsers:string[]) => {
-
-                console.log('RECEIVED ListOfConnectedUsers', connectedUsers);
-
                 // Update the observable state with the new list of users
                 this.#connectedBackofficeUserKeys.setValue(connectedUsers);
             });

--- a/ContentLock/Client/src/headerApps/contentLock.noUsersOnline.headerApp.ts
+++ b/ContentLock/Client/src/headerApps/contentLock.noUsersOnline.headerApp.ts
@@ -4,7 +4,6 @@ import ContentLockSignalrContext, { CONTENTLOCK_SIGNALR_CONTEXT } from '../globa
 import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import { CONTENTLOCK_ONLINEUSERS_MODAL } from '../modals/onlineusers.modal.token';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
-import { ConnectedBackofficeUsers } from '../interfaces/ConnectedBackofficeUsers';
 
 @customElement('contentlock-nousers-online-headerapp')
 export class ContentLockNoUsersOnlineHeaderApp extends UmbHeaderAppButtonElement {
@@ -13,7 +12,7 @@ export class ContentLockNoUsersOnlineHeaderApp extends UmbHeaderAppButtonElement
     private _totalConnectedUsers: number | undefined;
 
     @state()
-    private _connectedUsers?: ConnectedBackofficeUsers[];
+    private _connectedUserKeys?: string[];
 
     @state()
     private _enableOnlineUsers: boolean = true;
@@ -25,9 +24,11 @@ export class ContentLockNoUsersOnlineHeaderApp extends UmbHeaderAppButtonElement
 		super();
 
         this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT, (signalrContext: ContentLockSignalrContext) => {
-            this.observe(observeMultiple([signalrContext.totalConnectedUsers, signalrContext.connectedUsers, signalrContext.EnableOnlineUsers]), ([totalConnectedUsers, connectedUsers, enableOnlineUsers]) => {
+            this.observe(observeMultiple([signalrContext.totalConnectedUsers, signalrContext.connectedUserKeys, signalrContext.EnableOnlineUsers]), ([totalConnectedUsers, connectedUserKeys, enableOnlineUsers]) => {
                 this._totalConnectedUsers = totalConnectedUsers;
-                this._connectedUsers = connectedUsers;
+
+                console.log('connected user keys observed in SignalR global CTX', connectedUserKeys);
+                this._connectedUserKeys = connectedUserKeys;
 
                 // This is an observable from SignalR watching the AppSettings/Options
                 // TODO: Perhaps can retire this and use the condition approach when HeaderApps supports it
@@ -42,11 +43,8 @@ export class ContentLockNoUsersOnlineHeaderApp extends UmbHeaderAppButtonElement
 	}
 
     async #openUserListModal() {
-        await this.#modalManagerCtx?.open(this, CONTENTLOCK_ONLINEUSERS_MODAL, { 
-            data: {
-                users: this._connectedUsers ?? []
-            }
-        });
+        console.log('What is value of connected users when opening modal', this._connectedUserKeys);
+        await this.#modalManagerCtx?.open(this, CONTENTLOCK_ONLINEUSERS_MODAL);
     };
 
 	override render() {

--- a/ContentLock/Client/src/headerApps/contentLock.noUsersOnline.headerApp.ts
+++ b/ContentLock/Client/src/headerApps/contentLock.noUsersOnline.headerApp.ts
@@ -26,8 +26,6 @@ export class ContentLockNoUsersOnlineHeaderApp extends UmbHeaderAppButtonElement
         this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT, (signalrContext: ContentLockSignalrContext) => {
             this.observe(observeMultiple([signalrContext.totalConnectedUsers, signalrContext.connectedUserKeys, signalrContext.EnableOnlineUsers]), ([totalConnectedUsers, connectedUserKeys, enableOnlineUsers]) => {
                 this._totalConnectedUsers = totalConnectedUsers;
-
-                console.log('connected user keys observed in SignalR global CTX', connectedUserKeys);
                 this._connectedUserKeys = connectedUserKeys;
 
                 // This is an observable from SignalR watching the AppSettings/Options
@@ -43,7 +41,6 @@ export class ContentLockNoUsersOnlineHeaderApp extends UmbHeaderAppButtonElement
 	}
 
     async #openUserListModal() {
-        console.log('What is value of connected users when opening modal', this._connectedUserKeys);
         await this.#modalManagerCtx?.open(this, CONTENTLOCK_ONLINEUSERS_MODAL);
     };
 

--- a/ContentLock/Client/src/interfaces/ConnectedBackofficeUsers.ts
+++ b/ContentLock/Client/src/interfaces/ConnectedBackofficeUsers.ts
@@ -1,4 +1,3 @@
 export interface ConnectedBackofficeUsers {
     userKey: string;
-    userName: string;
   }

--- a/ContentLock/Client/src/interfaces/ConnectedBackofficeUsers.ts
+++ b/ContentLock/Client/src/interfaces/ConnectedBackofficeUsers.ts
@@ -1,3 +1,0 @@
-export interface ConnectedBackofficeUsers {
-    userKey: string;
-  }

--- a/ContentLock/Client/src/modals/onlineusers.modal.token.ts
+++ b/ContentLock/Client/src/modals/onlineusers.modal.token.ts
@@ -1,8 +1,6 @@
 import { UmbModalToken } from "@umbraco-cms/backoffice/modal";
-import { ConnectedBackofficeUsers } from "../interfaces/ConnectedBackofficeUsers";
 
 export interface OnlineUsersModalData {
-    users: ConnectedBackofficeUsers[];
 }
 
 export interface OnlineUsersModalValue {

--- a/ContentLock/Client/src/modals/onlineusers.modal.ts
+++ b/ContentLock/Client/src/modals/onlineusers.modal.ts
@@ -1,8 +1,9 @@
-import { css, customElement, html, state } from "@umbraco-cms/backoffice/external/lit";
+import { css, customElement, html, state, nothing } from "@umbraco-cms/backoffice/external/lit";
 import { UmbModalBaseElement, UmbModalRejectReason } from "@umbraco-cms/backoffice/modal";
 import { OnlineUsersModalData, OnlineUsersModalValue } from "./onlineusers.modal.token";
-import { UMB_USER_DETAIL_STORE_CONTEXT, UmbUserDetailRepository, UmbUserItemModel, UmbUserItemRepository } from "@umbraco-cms/backoffice/user";
+import { UmbUserItemModel, UmbUserItemRepository } from "@umbraco-cms/backoffice/user";
 import ContentLockSignalrContext, { CONTENTLOCK_SIGNALR_CONTEXT } from "../globalContexts/contentlock.signalr.context";
+import { UMB_CURRENT_USER_CONTEXT } from "@umbraco-cms/backoffice/current-user";
 
 @customElement("contentlock-onlineusers-modal")
 export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModalData, OnlineUsersModalValue>
@@ -13,19 +14,37 @@ export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModa
     @state()
     _connectedUserKeys: string[] = [];
 
+    @state()
+    _currentUserKey?: string;
+
     #userItemRepository = new UmbUserItemRepository(this);
 
     constructor() {
         super();
 
-        this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT, (signalrContext: ContentLockSignalrContext) => {
-            this.observe(signalrContext.connectedUserKeys, (connectedUserKeys) => {
-                console.log('KEYS from Global CTX in MODAL', connectedUserKeys);
+        // TODO: Make this a routable modal
+        // Can a modal have a condition so if setting is not enabled then we can route to
+
+        this.consumeContext(UMB_CURRENT_USER_CONTEXT, (currentUserCtx) => {
+            this.observe(currentUserCtx.unique, (unique) => {
+                this._currentUserKey = unique;
+            });
+        });
+
+        this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT, (signalrCtx: ContentLockSignalrContext) => {
+            // The list of GUID connected users as keys/uniques
+            this.observe(signalrCtx.connectedUserKeys, async (connectedUserKeys) => {
                 this._connectedUserKeys = connectedUserKeys;
 
-                // TODO use repository (Whats the difference between items and requestItems ?)
-                // this.#userItemRepository.items()
-                // this.#userItemRepository.requestItems('');
+                // Get users from the repo and observe it
+                // TODO: Why does it not work when a user updates their name or avatar?
+                // However when new user logs in or out it reactively shows them with the model open
+                const userItemsObservable = (await this.#userItemRepository.requestItems(connectedUserKeys)).asObservable();
+
+                // Observe the users we wanted to request/fetch and assign them to property/state
+                this.observe(userItemsObservable, (userItems) => {
+                    this._connectedUsersModels = userItems;
+                });
             });
         });
     }
@@ -39,10 +58,21 @@ export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModa
             <umb-body-layout headline=${this.localize.term('contentLockUsersModal_modalHeader')}>
                 <uui-box headline=${this.localize.term('contentLockUsersModal_listOfUsers')}>
                     ${this._connectedUsersModels?.map((user) => {
-                        console.log('User to output to HTML', user);
+                        // Get the last item in the array of avatar URLs as this is the biggest or fallback to nothing
+                        const avatarUrl = user.avatarUrls?.[user.avatarUrls.length - 1] ?? '';
                         return html`
-                            <div>
-                                <uui-avatar name="${user.name}" img-src="${user.avatarUrls[0]}"></uui-avatar> ${user.name}
+                            <div class="user-detail">
+                                <uui-avatar name="${user.name}" img-src="${avatarUrl}">
+                                    <!-- TODO: This is to display how many SignalR connections the user has (aka tabs open etc) -->
+                                    <uui-badge color="default" look="primary">2</uui-badge>
+                                </uui-avatar>
+                                <span>${user.name}</span>
+                                
+                                <!-- Show a tag if the user is the current user -->
+                                ${user.unique === this._currentUserKey
+                                    ? html `<uui-tag color="default" look="outline">You</uui-tag>`
+                                    : nothing
+                                }
                             </div>
                         `;
                     })}
@@ -65,8 +95,19 @@ export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModa
             padding-bottom:0;
         }
 
-        div {
-            margin: var(--uui-size-5) 0;
+        .user-detail {
+            display: flex;
+            align-items: center;
+            gap: var(--uui-size-4);
+            margin: var(--uui-size-3) 0;
+        }
+
+        .user-detail:last-child {
+            margin-bottom: 0;
+        }
+
+        uui-avatar {
+            font-size: var(--uui-size-6);
         }
     `;
 }

--- a/ContentLock/Client/src/modals/onlineusers.modal.ts
+++ b/ContentLock/Client/src/modals/onlineusers.modal.ts
@@ -22,9 +22,6 @@ export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModa
     constructor() {
         super();
 
-        // TODO: Make this a routable modal
-        // Can a modal have a condition so if setting is not enabled then we can route to
-
         this.consumeContext(UMB_CURRENT_USER_CONTEXT, (currentUserCtx) => {
             this.observe(currentUserCtx.unique, (unique) => {
                 this._currentUserKey = unique;
@@ -58,14 +55,9 @@ export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModa
             <umb-body-layout headline=${this.localize.term('contentLockUsersModal_modalHeader')}>
                 <uui-box headline=${this.localize.term('contentLockUsersModal_listOfUsers')}>
                     ${this._connectedUsersModels?.map((user) => {
-                        // Get the last item in the array of avatar URLs as this is the biggest or fallback to nothing
-                        const avatarUrl = user.avatarUrls?.[user.avatarUrls.length - 1] ?? '';
                         return html`
                             <div class="user-detail">
-                                <uui-avatar name="${user.name}" img-src="${avatarUrl}">
-                                    <!-- TODO: This is to display how many SignalR connections the user has (aka tabs open etc) -->
-                                    <uui-badge color="default" look="primary">2</uui-badge>
-                                </uui-avatar>
+                                <umb-user-avatar name="${user.name}" .imgUrls=${user.avatarUrls ?? []}></umb-user-avatar>
                                 <span>${user.name}</span>
                                 
                                 <!-- Show a tag if the user is the current user -->

--- a/ContentLock/Client/src/modals/onlineusers.modal.ts
+++ b/ContentLock/Client/src/modals/onlineusers.modal.ts
@@ -1,44 +1,31 @@
 import { css, customElement, html, state } from "@umbraco-cms/backoffice/external/lit";
 import { UmbModalBaseElement, UmbModalRejectReason } from "@umbraco-cms/backoffice/modal";
 import { OnlineUsersModalData, OnlineUsersModalValue } from "./onlineusers.modal.token";
-import { UMB_USER_DETAIL_STORE_CONTEXT, UmbUserItemModel } from "@umbraco-cms/backoffice/user";
+import { UMB_USER_DETAIL_STORE_CONTEXT, UmbUserDetailRepository, UmbUserItemModel, UmbUserItemRepository } from "@umbraco-cms/backoffice/user";
 import ContentLockSignalrContext, { CONTENTLOCK_SIGNALR_CONTEXT } from "../globalContexts/contentlock.signalr.context";
 
 @customElement("contentlock-onlineusers-modal")
 export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModalData, OnlineUsersModalValue>
 {
     @state()
-    _allUsersModels?: UmbUserItemModel[] = [];
-
-    @state()
     _connectedUsersModels?: UmbUserItemModel[] = [];
 
     @state()
     _connectedUserKeys: string[] = [];
 
+    #userItemRepository = new UmbUserItemRepository(this);
+
     constructor() {
         super();
-
-        this.consumeContext(UMB_USER_DETAIL_STORE_CONTEXT, (userDetailStore) => {
-            this.observe(userDetailStore.all(), (allUsers) => {
-                console.log('OBSERVED allUsers', allUsers);
-                this._allUsersModels = allUsers;
-            });
-        });
 
         this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT, (signalrContext: ContentLockSignalrContext) => {
             this.observe(signalrContext.connectedUserKeys, (connectedUserKeys) => {
                 console.log('KEYS from Global CTX in MODAL', connectedUserKeys);
                 this._connectedUserKeys = connectedUserKeys;
 
-                if(!this._allUsersModels) {
-                    console.error('No allUsersModels found, cannot filter connected users');
-                    return;
-                }
-
-                // Add filtering to only get the connected users
-                this._connectedUsersModels = this._allUsersModels?.filter((user) => this._connectedUserKeys.includes(user.unique));
-                console.log('OBSERVED filtered users', this._connectedUsersModels);
+                // TODO use repository (Whats the difference between items and requestItems ?)
+                // this.#userItemRepository.items()
+                // this.#userItemRepository.requestItems('');
             });
         });
     }

--- a/ContentLock/Client/src/modals/onlineusers.modal.ts
+++ b/ContentLock/Client/src/modals/onlineusers.modal.ts
@@ -1,12 +1,25 @@
 import { css, customElement, html } from "@umbraco-cms/backoffice/external/lit";
 import { UmbModalBaseElement, UmbModalRejectReason } from "@umbraco-cms/backoffice/modal";
 import { OnlineUsersModalData, OnlineUsersModalValue } from "./onlineusers.modal.token";
+import { UMB_USER_ITEM_STORE_CONTEXT, UmbUserItemModel } from "@umbraco-cms/backoffice/user";
 
 @customElement("contentlock-onlineusers-modal")
 export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModalData, OnlineUsersModalValue>
 {
+    #users?: UmbUserItemModel[] = [];
+
     constructor() {
         super();
+        
+        // From the modal data passed in
+        // Convert to an array of string GUIDs for the user keys
+        const userKeys = this.data?.users.map((user) => user.userKey) ?? [];
+
+        this.consumeContext(UMB_USER_ITEM_STORE_CONTEXT, (userStore) => {
+            this.observe(userStore.items(userKeys), (users) => {
+                this.#users = users;
+            });
+        });
     }
     
     #handleClose() {
@@ -17,10 +30,10 @@ export class OnlineUsersModalElement extends UmbModalBaseElement<OnlineUsersModa
         return html`
             <umb-body-layout headline=${this.localize.term('contentLockUsersModal_modalHeader')}>
                 <uui-box headline=${this.localize.term('contentLockUsersModal_listOfUsers')}>
-                    ${this.data?.users.map((user) => {
+                    ${this.#users?.map((user) => {
                         return html`
                             <div>
-                                <uui-avatar name="${user.userName}"></uui-avatar> ${user.userName}
+                                <uui-avatar name="${user.name}" img-src="${user.avatarUrls[0]}"></uui-avatar> ${user.name}
                             </div>
                         `;
                     })}

--- a/ContentLock/Interfaces/IContentLockHubEvents.cs
+++ b/ContentLock/Interfaces/IContentLockHubEvents.cs
@@ -34,7 +34,7 @@ public interface IContentLockHubEvents
 
     public Task UserDisconnected(Guid? connectedUserKey);
 
-    public Task ReceiveListOfConnectedUsers(ConcurrentDictionary<Guid, string> connectedUsers);
+    public Task ReceiveListOfConnectedUsers(Guid[] connectedUsersKeys);
 
     public Task ReceiveLatestOptions(ContentLockOptions currentOptions);
 }

--- a/ContentLock/Interfaces/IContentLockHubEvents.cs
+++ b/ContentLock/Interfaces/IContentLockHubEvents.cs
@@ -30,7 +30,7 @@ public interface IContentLockHubEvents
     /// <param name="contentKeys">Identifies the content items from which the locks will be removed.</param>
     public Task RemoveLocksToClients(IEnumerable<Guid> contentKeys);
 
-    public Task UserConnected(Guid? connectedUserKey, string connectedUserName);
+    public Task UserConnected(Guid? connectedUserKey);
 
     public Task UserDisconnected(Guid? connectedUserKey);
 

--- a/ContentLock/SignalR/ContentLockHub.cs
+++ b/ContentLock/SignalR/ContentLockHub.cs
@@ -69,7 +69,6 @@ public class ContentLockHub : Hub<IContentLockHubEvents>
     private async Task AddNewUserToListOfConnectedUsers()
     {
         var currentUmbUser = this.Context.User?.GetUmbracoIdentity();
-        var currentUserName = currentUmbUser?.GetRealName() ?? "Unknown User";
         var currentUserKey = currentUmbUser?.GetUserKey();
         
         // Need to keep track of the connections, as a user may have one or more connections (tabs)
@@ -90,7 +89,7 @@ public class ContentLockHub : Hub<IContentLockHubEvents>
             {
                 // Notify a client has connected
                 // Calls everyone else who is already connected to update them that someone new joined
-                await Clients.Others.UserConnected(currentUserKey.Value, currentUserName);
+                await Clients.Others.UserConnected(currentUserKey.Value);
             }
     
             // Sends the newly connected client

--- a/ContentLock/SignalR/ContentLockHub.cs
+++ b/ContentLock/SignalR/ContentLockHub.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
 
+using Umbraco.Cms.Core.Collections;
 using Umbraco.Cms.Web.Common.Authorization;
 using Umbraco.Extensions;
 
@@ -16,7 +17,9 @@ public class ContentLockHub : Hub<IContentLockHubEvents>
 {
     private readonly IContentLockService _contentLockService;
     private readonly IOptionsMonitor<ContentLockOptions> _options;
-    private static readonly ConcurrentDictionary<Guid, string> ConnectedUsers = new();
+    
+    // Change to track 1 or more connection IDs per User Key
+    private static readonly ConcurrentDictionary<Guid, ConcurrentHashSet<string>> ConnectedUsers = new();
 
     public ContentLockHub(IContentLockService contentLockService, IOptionsMonitor<ContentLockOptions> options)
     {
@@ -65,24 +68,34 @@ public class ContentLockHub : Hub<IContentLockHubEvents>
 
     private async Task AddNewUserToListOfConnectedUsers()
     {
-        var currentUser = this.Context.User;
         var currentUmbUser = this.Context.User?.GetUmbracoIdentity();
         var currentUserName = currentUmbUser?.GetRealName() ?? "Unknown User";
         var currentUserKey = currentUmbUser?.GetUserKey();
-
+        
+        // Need to keep track of the connections, as a user may have one or more connections (tabs)
+        var connectionId = this.Context.ConnectionId;
+        
         // Add new user to the list of connected users
-        // Only if the user is not already in the list - check by using the currentUserKey
-        if (currentUserKey.HasValue && !ConnectedUsers.ContainsKey(currentUserKey.Value))
+        if (currentUserKey.HasValue)
         {
-            ConnectedUsers.TryAdd(currentUserKey.Value, currentUserName);
-
-            // Notify a client has connected
-            // Calls everyone else who is already connected to update them that someone new joined
-            await Clients.Others.UserConnected(currentUserKey.Value, currentUserName);
-
+            // Get or create user's connection dictionary
+            var userConnections = ConnectedUsers.GetOrAdd(currentUserKey.Value, _ => new ConcurrentHashSet<string>());
+            
+            // Add the Connection ID associated to the Users GUID
+            userConnections.TryAdd(connectionId);
+            
+            // Only notify others if this is the user's first connection
+            // As they could be using different tabs or perhaps browser
+            if (userConnections.Count == 1)
+            {
+                // Notify a client has connected
+                // Calls everyone else who is already connected to update them that someone new joined
+                await Clients.Others.UserConnected(currentUserKey.Value, currentUserName);
+            }
+    
             // Sends the newly connected client
-            // The current list of connected users
-            await Clients.Caller.ReceiveListOfConnectedUsers(ConnectedUsers);
+            // The current list of connected users GUID/Keys
+            await Clients.Caller.ReceiveListOfConnectedUsers(ConnectedUsers.Keys.ToArray());
         }
     }
 
@@ -90,13 +103,21 @@ public class ContentLockHub : Hub<IContentLockHubEvents>
     {
         var currentUmbUser = this.Context.User?.GetUmbracoIdentity();
         var currentUserKey = currentUmbUser?.GetUserKey();
+        var connectionId = this.Context.ConnectionId;
 
-        if (currentUserKey.HasValue)
+        if (currentUserKey.HasValue && ConnectedUsers.TryGetValue(currentUserKey.Value, out var userConnections))
         {
-            ConnectedUsers.TryRemove(currentUserKey.Value, out _);
+            // Remove this specific connection from Hashset associated to the User Key
+            userConnections.Remove(connectionId);
 
-            // Notify everyone that someone has disconnected
-            await Clients.All.UserDisconnected(currentUserKey.Value);
+            // If user has no more connections, remove them entirely from dictionary
+            if (userConnections.Count == 0)
+            {
+                ConnectedUsers.TryRemove(currentUserKey.Value, out _);
+                
+                // Notify everyone that someone has disconnected
+                await Clients.All.UserDisconnected(currentUserKey.Value);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #16

## Problem
For each user key/unique we need to track each connection ID/Key (as each new browser tab will create a new connection to SignalR that we need to keep track of)

* SignalR hub only sends the Key/Unique of the users connected
* We use the `UmbUserItemRepository` to requestItems from Umbraco with the array of user GUIDs to get their names and avatars