### PR TITLE
Reactive SignalR Browser LogLevel

### DIFF
--- a/ContentLock.Website/appsettings.json
+++ b/ContentLock.Website/appsettings.json
@@ -41,7 +41,8 @@
       }
     }
   },
-  "ContentLock": {
+  "ContentLock": { 
+    "SignalRClientLogLevel": "Trace",
     "OnlineUsers": {
       "Enable": true,
       "Sounds": {

--- a/ContentLock/Client/src/globalContexts/signalr.logger.ts
+++ b/ContentLock/Client/src/globalContexts/signalr.logger.ts
@@ -1,0 +1,45 @@
+import { ILogger, LogLevel } from "@microsoft/signalr";
+import { UmbClassInterface } from "@umbraco-cms/backoffice/class-api";
+import { Observable } from "@umbraco-cms/backoffice/observable-api";
+
+export class SignalrLogger implements ILogger {
+
+    private _currentLogLevel?: LogLevel;
+
+    constructor(host: UmbClassInterface, logLevelObservable: Observable<LogLevel>){
+        // Use the `observe` method to subscribe to the log level observable
+        host.observe(logLevelObservable, (logLevel) => {
+            console.log(`SignalR Log Level changed to: ${logLevel}`);
+            this._currentLogLevel = logLevel;
+        });
+    }
+    
+    log(logLevel: LogLevel, message: string) {
+        // Only log messages that meet or exceed the current log level
+        if (this._currentLogLevel !== undefined && logLevel >= this._currentLogLevel) {
+            switch (logLevel) {
+                case LogLevel.Trace:
+                    console.info(`[Content Lock SignalR] TRACE: ${message}`);
+                    break;
+                case LogLevel.Debug:
+                    console.debug(`[Content Lock SignalR] DEBUG: ${message}`);
+                    break;
+                case LogLevel.Information:
+                    console.info(`[Content Lock SignalR] INFO: ${message}`);
+                    break;
+                case LogLevel.Warning:
+                    console.warn(`[Content Lock SignalR] WARNING: ${message}`);
+                    break;
+                case LogLevel.Error:
+                    console.error(`[Content Lock SignalR] ERROR: ${message}`);
+                    break;
+                case LogLevel.Critical:
+                    console.error(`[Content Lock SignalR] CRITICAL: ${message}`);
+                    break;
+                default:
+                    console.log(`[Content Lock SignalR] LOG: ${message}`);
+                    break;
+            }
+        }
+    }
+}

--- a/ContentLock/Client/src/interfaces/ContentLockOptions.ts
+++ b/ContentLock/Client/src/interfaces/ContentLockOptions.ts
@@ -1,5 +1,6 @@
 export interface ContentLockOptions {
     onlineUsers: OnlineUsersOptions;
+    signalRClientLogLevel: string;
 }
 
 export interface OnlineUsersOptions {

--- a/ContentLock/Options/ContentLockOptions.cs
+++ b/ContentLock/Options/ContentLockOptions.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace ContentLock.Options;
 
 public class ContentLockOptions
@@ -8,7 +10,16 @@ public class ContentLockOptions
     /// Settings related to the feature of showing the number of online users in the backoffice
     /// </summary>
     public OnlineUsersOptions OnlineUsers { get; set; } = new();
-
+    
+    /// <summary>
+    /// Used to set the log level of the SignalR Javascript client
+    /// </summary>
+    /// <remarks>
+    /// NOTE: This option is not reactively updated in the backoffice
+    /// As we are unable to change the log level of the SignalR client once its booted up
+    /// </remarks>
+    public string SignalRClientLogLevel { get; set; } = "Info";
+    
     public class OnlineUsersOptions
     {
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -50,14 +50,6 @@ Content Lock has the following options available to configure.
 | OnlineUsers.Sounds.LoginSound | A path to an audio file that a browser can play when a new user logins to the Umbraco backoffice | `"/App_Plugins/ContentLock/sounds/login.mp3"`
 | OnlineUsers.Sounds.LogoutSound | A path to an audio file that a browser can play when a user logs out of the Umbraco backoffice | `"/App_Plugins/ContentLock/sounds/logout.mp3"`
 
-### Reactive Options
-Changing any of these options will be changed instantly without having to redeploy or restart the application. For example you could change the value **OnlineUsers.Enable** and this will instantly toggle the number of connected users in the backoffice in the top right of Umbraco.
-
-You can see this in action here and how it was coded if you are curious: 
-
-[![How to use SignalR with Umbraco for real-time options](https://img.youtube.com/vi/MZfeUKSO8h4/0.jpg)](https://www.youtube.com/watch?v=MZfeUKSO8h4)
-
-
 ### AppSettings
 
 ```json
@@ -77,12 +69,23 @@ You can see this in action here and how it was coded if you are curious:
 
 ### Environment Variables
 ```
-ContentLock__SignalRClientLogLevel=Trace
+ContentLock__SignalRClientLogLevel=Info
 ContentLock__OnlineUsers__Enable=true
 ContentLock__OnlineUsers__Sounds__Enable=true
 ContentLock__OnlineUsers__Sounds__LoginSound=https://some-snazzy-sound.com/sfx-login.mp3
 ContentLock__OnlineUsers__Sounds__LogoutSound=/App_Plugins/SomePlace/logout.mp3
 ```
+
+### Reactive Options
+
+> [!TIP]
+> Changing any of these options will be changed **instantly** without having to redeploy or restart the application.
+
+For example you could change the value **OnlineUsers.Enable** and this will instantly toggle the number of connected users in the backoffice in the top right of Umbraco.
+You can see this in action here and [how it was coded](https://blog.hackmakedo.com/2025/04/28/using-signalr-ioptionsmonitor-with-umbraco-bellissima-for-reactive-net-options/) if you are curious:
+
+[![How to use SignalR with Umbraco for real-time options](https://img.youtube.com/vi/MZfeUKSO8h4/0.jpg)](https://www.youtube.com/watch?v=MZfeUKSO8h4)
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,39 @@
   - Prevents actions like publish, unpublish, and save for nodes that are currently locked.
 
 
-## Options
-Content Lock has the following options available to configure
+Trace
+Debug
+Information or Info
+Warning or Warn
+Error
+Critical
+None
 
-## AppSettings
+## Options
+Content Lock has the following options available to configure. 
+
+| Setting | Description | Default Value |
+| -- | -- | -- |
+| SignalRClientLogLevel | The SignalR log level of printing messages to the browser console can be set as one of the following values. `Trace`, `Debug`, `Information` or `Info`, `Warning` or `Warn`, `Error`, `Critical` and `None` | `"Info"` |
+| OnlineUsers.Enable | A boolean flag to decide if to displays a header app in the top right with the number of active users connected to the Umbraco backoffice | true
+| OnlineUsers.Sounds.Enable | A boolean flag to decide if to play audio notifications when a user logs in or out of the backoffice | true
+| OnlineUsers.Sounds.LoginSound | A path to an audio file that a browser can play when a new user logins to the Umbraco backoffice | `"/App_Plugins/ContentLock/sounds/login.mp3"`
+| OnlineUsers.Sounds.LogoutSound | A path to an audio file that a browser can play when a user logs out of the Umbraco backoffice | `"/App_Plugins/ContentLock/sounds/logout.mp3"`
+
+### Reactive Options
+Changing any of these options will be changed instantly without having to redeploy or restart the application. For example you could change the value **OnlineUsers.Enable** and this will instantly toggle the number of connected users in the backoffice in the top right of Umbraco.
+
+You can see this in action here and how it was coded if you are curious: 
+
+[![How to use SignalR with Umbraco for real-time options](https://img.youtube.com/vi/MZfeUKSO8h4/0.jpg)](https://www.youtube.com/watch?v=MZfeUKSO8h4)
+
+
+### AppSettings
 
 ```json
 ...
 "ContentLock": {
+  "SignalRClientLogLevel": "Info",
   "OnlineUsers": {
     "Enable": true,
     "Sounds": {
@@ -50,8 +75,9 @@ Content Lock has the following options available to configure
 }
 ```
 
-## Environment Variables
+### Environment Variables
 ```
+ContentLock__SignalRClientLogLevel=Trace
 ContentLock__OnlineUsers__Enable=true
 ContentLock__OnlineUsers__Sounds__Enable=true
 ContentLock__OnlineUsers__Sounds__LoginSound=https://some-snazzy-sound.com/sfx-login.mp3

--- a/appsettings-schema.umbraco.community.contentlock.json
+++ b/appsettings-schema.umbraco.community.contentlock.json
@@ -13,7 +13,9 @@
         "OnlineUsers": {
           "description": "Settings related to the online users feature.",
           "type": "object",
-          "required": ["Enable"],
+          "required": [
+            "Enable"
+          ],
           "properties": {
             "Enable": {
               "type": "boolean",
@@ -42,7 +44,20 @@
               }
             }
           }
+        },
+        "SignalRClientLogLevel": {
+          "description": "Used to set the log level of the SignalR Javascript client.",
+          "enum": [
+            "Trace",
+            "Debug",
+            "Information",
+            "Warning",
+            "Error",
+            "Critical",
+            "None"
+          ]
         }
       }
     }
   }
+}


### PR DESCRIPTION
Fixes issue #23 

Adds a custom SignalR logger that uses an observable of the set loglevel from settings
Use RXJS pipe and map to transform the string to the loglevel enum which in turn is an int

## New Setting: SignalRClientLogLevel
The clientside log level of printing messages to the browser console can be set as one of the following values for the setting `SignalRClientLogLevel`

* Trace
* Debug
* Information or Info
* Warning or Warn
* Error
* Critical
* None

```json
...
"ContentLock": {
  "SignalRClientLogLevel": "Trace",
  "OnlineUsers": {
    "Enable": true,
    "Sounds": {
      "Enable": true,
      "LoginSound":"/App_Plugins/ContentLock/sounds/login.mp3",
      "LogoutSound":"/App_Plugins/ContentLock/sounds/logout.mp3"
    }
  }
}
```

---

## Copilot Summary
This pull request introduces a new feature to configure the SignalR client log level dynamically and updates related components to support this functionality. It includes changes to the configuration files, client-side context, and logging implementation. Below is a summary of the most important changes:

### SignalR Client Log Level Configuration

* **Added SignalR client log level to configuration files**:
  - Introduced the `SignalRClientLogLevel` setting in `ContentLock.Website/appsettings.json` with a default value of `"Trace"`.
  - Updated `appsettings-schema.umbraco.community.contentlock.json` to include the `SignalRClientLogLevel` property with a description and an enumeration of valid log levels.

* **Updated `ContentLockOptions` to include SignalR client log level**:
  - Added a new `signalRClientLogLevel` property in `ContentLock/Client/src/interfaces/ContentLockOptions.ts`.
  - Extended the `ContentLockOptions` class in `ContentLock/Options/ContentLockOptions.cs` to include a `SignalRClientLogLevel` property with a default value of `"Info"`.

### Client-Side SignalR Context Enhancements

* **Enhanced `ContentLockSignalrContext` to handle log level dynamically**:
  - Imported the `SignalrLogger` class and added a `SignalrClientLogLevel` observable to map the configured log level to SignalR's internal log levels. [[1]](diffhunk://#diff-513962592fa6b0fe48f1f24d89adfe76a6e09db0e3ddf3063fa51bb36d1d5fb4R9-R10) [[2]](diffhunk://#diff-513962592fa6b0fe48f1f24d89adfe76a6e09db0e3ddf3063fa51bb36d1d5fb4R74-L77)
  - Updated the SignalR connection setup to use the new `SignalrLogger` instead of a static log level.

### Custom SignalR Logger Implementation

* **Introduced `SignalrLogger` class**:
  - Created a custom logger in `ContentLock/Client/src/globalContexts/signalr.logger.ts` to dynamically adjust logging behavior based on the current log level. It subscribes to the log level observable and logs messages accordingly.
