### PR TITLE
Improve no locks in the dashboard

### DIFF
--- a/ContentLock/Client/src/dashboards/dashboard.element.ts
+++ b/ContentLock/Client/src/dashboards/dashboard.element.ts
@@ -258,8 +258,8 @@ export class ContentLockDashboardElement extends UmbElementMixin(LitElement) {
                     @deselected="${this.#onDeselected}"
                     @ordered="${this.#onOrdering}"></umb-table>`
               : html`
-                <uui-box headline="No locks">
-                  <h2>🎉 Zip, zero, nada</h2>
+                <uui-box headline=${this.localize.term('contentLockDashboard_noLocks')}>
+                  <h2><umb-localize key="contentLockDashboard_noLocksMessage"></umb-localize></h2>
                 </uui-box>
               `}
           </uui-scroll-container>

--- a/ContentLock/Client/src/dashboards/dashboard.element.ts
+++ b/ContentLock/Client/src/dashboards/dashboard.element.ts
@@ -248,17 +248,24 @@ export class ContentLockDashboardElement extends UmbElementMixin(LitElement) {
       <div class="grid">
         <div class="container">
           <uui-scroll-container>
-              <umb-table 
-                  .config=${this._tableConfig} 
-                  .columns=${this._tableColumns} 
-                  .items=${this._tableItems}
-                  @selected="${this.#onSelected}"
-                  @deselected="${this.#onDeselected}"
-                  @ordered="${this.#onOrdering}"></umb-table>
+            ${this._tableItems.length > 0
+              ? html`
+                  <umb-table 
+                    .config=${this._tableConfig} 
+                    .columns=${this._tableColumns} 
+                    .items=${this._tableItems}
+                    @selected="${this.#onSelected}"
+                    @deselected="${this.#onDeselected}"
+                    @ordered="${this.#onOrdering}"></umb-table>`
+              : html`
+                <uui-box headline="No locks">
+                  <h2>🎉 Zip, zero, nada</h2>
+                </uui-box>
+              `}
           </uui-scroll-container>
         </div>
         <div class="container entries-col">
-          <uui-box class="entries">
+          <uui-box>
             <span slot="headline">
               <uui-icon name="icon-combination-lock"></uui-icon> 
               <umb-localize key="contentLockDashboard_pagesCheckedOutTitle"></umb-localize>
@@ -296,13 +303,12 @@ export class ContentLockDashboardElement extends UmbElementMixin(LitElement) {
         grid-template-columns: 1fr 350px;
       }
 
-      .entries {
+      uui-box {
         text-align: center;
-        background-color: var(--uui-color-current-emphasis);
       }
 
       h2 {
-        color: var(--uui-palette-violet-blue);
+        color: var(--uui-color-current-contrast);
         font-size: var(--uui-size-14);
       }
 

--- a/ContentLock/Client/src/localizations/cy.ts
+++ b/ContentLock/Client/src/localizations/cy.ts
@@ -8,6 +8,8 @@
         lastEditedHeader: 'Golygiad Diwethaf',
         unlockAction: 'Datgloi',
         pagesCheckedOutTitle: 'Tudalennau wedi\'u Gwirio Allan',
+        noLocks: 'No locks',
+        noLocksMessage: '🎉 Zip, zero, nada'
     },
     contentLockFooterApp: {
         lockedByYou: 'Mae\'r dudalen hon wedi\'i chloi gennych chi',

--- a/ContentLock/Client/src/localizations/dk.ts
+++ b/ContentLock/Client/src/localizations/dk.ts
@@ -8,6 +8,8 @@ export default {
         lastEditedHeader: 'Sidst redigeret',
         unlockAction: 'Lås op',
         pagesCheckedOutTitle: 'Låste sider',
+        noLocks: 'No locks',
+        noLocksMessage: '🎉 Zip, zero, nada'
     },
     contentLockFooterApp: {
         lockedByYou: 'Denne side er låst af dig',

--- a/ContentLock/Client/src/localizations/en.ts
+++ b/ContentLock/Client/src/localizations/en.ts
@@ -8,6 +8,8 @@ export default {
         lastEditedHeader: 'Last Edited',
         unlockAction: 'Unlock',
         pagesCheckedOutTitle: 'Pages Checked Out',
+        noLocks: 'No locks',
+        noLocksMessage: '🎉 Zip, zero, nada'
     },
     contentLockFooterApp: {
         lockedByYou: 'This page is locked by you',

--- a/ContentLock/Client/src/localizations/fr.ts
+++ b/ContentLock/Client/src/localizations/fr.ts
@@ -8,6 +8,8 @@ export default {
         lastEditedHeader: 'Dernière modification',
         unlockAction: 'Déverrouiller',
         pagesCheckedOutTitle: 'Pages verrouillées',
+        noLocks: 'No locks',
+        noLocksMessage: '🎉 Zip, zero, nada'
     },
     contentLockFooterApp: {
         lockedByYou: 'Vous avez verrouillé cette page',

--- a/ContentLock/Client/src/localizations/it.ts
+++ b/ContentLock/Client/src/localizations/it.ts
@@ -8,6 +8,8 @@ export default {
         lastEditedHeader: 'Ultima modifica',
         unlockAction: 'Sblocca',
         pagesCheckedOutTitle: 'Pagine bloccate',
+        noLocks: 'No locks',
+        noLocksMessage: '🎉 Zip, zero, nada'
     },
     contentLockFooterApp: {
         lockedByYou: 'Questa pagina è bloccata da te',

--- a/ContentLock/Client/src/localizations/nl.ts
+++ b/ContentLock/Client/src/localizations/nl.ts
@@ -8,6 +8,8 @@ export default {
         lastEditedHeader: 'Laatst bewerkt',
         unlockAction: 'Ontgrendelen',
         pagesCheckedOutTitle: 'Vergrendelde pagina’s',
+        noLocks: 'No locks',
+        noLocksMessage: '🎉 Zip, zero, nada'
     },
     contentLockFooterApp: {
         lockedByYou: 'Deze pagina is door jou vergrendeld',

--- a/ContentLock/Client/src/localizations/tr.ts
+++ b/ContentLock/Client/src/localizations/tr.ts
@@ -1,29 +1,31 @@
 export default {
-    "contentLockDashboard": {
-        "label": "Ýçerik Kilidi",
-        "pageNameHeader": "Sayfa Adý",
-        "contentTypeHeader": "Ýçerik Türü",
-        "checkedOutByHeader": "Tarafýndan Kilitlendi",
-        "checkedOutAtHeader": "Kilitlendiði Zaman",
-        "lastEditedHeader": "Son Düzenleme",
-        "unlockAction": "Kilidi Aç",
-        "pagesCheckedOutTitle": "Kontrol Edilen Sayfalar"
+    contentLockDashboard: {
+        label: "ï¿½ï¿½erik Kilidi",
+        pageNameHeader: "Sayfa Adï¿½",
+        contentTypeHeader: "ï¿½ï¿½erik Tï¿½rï¿½",
+        checkedOutByHeader: "Tarafï¿½ndan Kilitlendi",
+        checkedOutAtHeader: "Kilitlendiï¿½i Zaman",
+        lastEditedHeader: "Son Dï¿½zenleme",
+        unlockAction: "Kilidi Aï¿½",
+        pagesCheckedOutTitle: "Kontrol Edilen Sayfalar",
+        noLocks: "No locks",
+        noLocksMessage: "ðŸŽ‰ Zip, zero, nada"
     },
-    "contentLockFooterApp": {
-        "lockedByYou": "Bu sayfa sizin tarafýnýzdan kilitlendi",
-        "lockedByAnother": "Bu sayfa {0} tarafýndan kilitlendi"
+    contentLockFooterApp: {
+        lockedByYou: "Bu sayfa sizin tarafï¿½nï¿½zdan kilitlendi",
+        lockedByAnother: "Bu sayfa {0} tarafï¿½ndan kilitlendi"
     },
-    "contentLockNotification": {
-        "lockedHeader": "Ýçerik Kilitlendi",
-        "lockedMessage": "Belge düzenlemeniz için kilitlendi.",
-        "unlockedHeader": "Ýçerik Kilidi Açýldý",
-        "unlockedMessage": "Belgenin kilidi açýldý, diðer kullanýcýlarýn düzenlemesine izin verildi.",
-        "bulkUnlockHeader": "Ýçerik Kilidi Açýldý",
-        "bulkUnlockMessage": "Seçilen içeriðin kilidi baþarýyla açýldý"
+    contentLockNotification: {
+        lockedHeader: "ï¿½ï¿½erik Kilitlendi",
+        lockedMessage: "Belge dï¿½zenlemeniz iï¿½in kilitlendi.",
+        unlockedHeader: "ï¿½ï¿½erik Kilidi Aï¿½ï¿½ldï¿½",
+        unlockedMessage: "Belgenin kilidi aï¿½ï¿½ldï¿½, diï¿½er kullanï¿½cï¿½larï¿½n dï¿½zenlemesine izin verildi.",
+        bulkUnlockHeader: "ï¿½ï¿½erik Kilidi Aï¿½ï¿½ldï¿½",
+        bulkUnlockMessage: "Seï¿½ilen iï¿½eriï¿½in kilidi baï¿½arï¿½yla aï¿½ï¿½ldï¿½"
     },
-    "contentLockPermission": {
-        "group": "Content Lock",
-        "label": "Unlocker",
-        "description": "Kullanýcý grubunun baþka bir kullanýcý tarafýndan kilitlenen bir belgenin kilidini açmasýna izin verir."
+    contentLockPermission: {
+        group: "Content Lock",
+        label: "Unlocker",
+        description: "Kullanï¿½cï¿½ grubunun baï¿½ka bir kullanï¿½cï¿½ tarafï¿½ndan kilitlenen bir belgenin kilidini aï¿½masï¿½na izin verir."
     }
 };


### PR DESCRIPTION
Fixes #22 

## Changes
* Adds uui-box with message of no locks
* Count of locks background colour removed - probably a bit too attention grabbing


## Before
![image](https://github.com/user-attachments/assets/cd881677-4290-4d3a-a8a3-780d42d674cb)


## After
![image](https://github.com/user-attachments/assets/ba08e421-4ed0-4e5a-8eab-3b8d03f1fcd6)

----

## Copilot Summary

This pull request updates the `ContentLockDashboardElement` component in `dashboard.element.ts` to improve user experience by adding a fallback message when there are no table items and simplifying the styling of elements. Below are the most important changes:

### User Experience Improvements:
* Added a fallback UI message ("No locks") with a headline and subheading when `_tableItems` is empty. This ensures users are informed when there are no locks to display.

### Styling Simplifications:
* Removed the `.entries` class and replaced it with direct styling for the `uui-box` element, simplifying the CSS structure.
* Updated the color of the `h2` element to use `--uui-color-current-contrast` instead of `--uui-palette-violet-blue` for better theme consistency.
