### PR TITLE
Updated `dk.ts`

### DIFF
--- a/ContentLock/Client/src/localizations/dk.ts
+++ b/ContentLock/Client/src/localizations/dk.ts
@@ -8,7 +8,7 @@ export default {
         lastEditedHeader: 'Sidst redigeret',
         unlockAction: 'Lås op',
         pagesCheckedOutTitle: 'Låste sider',
-        noLocks: 'No locks',
+        noLocks: 'Ingen låse',
         noLocksMessage: '🎉 Zip, zero, nada'
     },
     contentLockFooterApp: {


### PR DESCRIPTION
I can see you already have translations for most of the labels, but this one was missing.

[**Content Lock**](https://github.com/warrenbuckley/Umbraco.Community.ContentLock/blob/v15/dev/ContentLock/Client/src/localizations/dk.ts#L27) and [**Unlocker**](https://github.com/warrenbuckley/Umbraco.Community.ContentLock/blob/v15/dev/ContentLock/Client/src/localizations/dk.ts#L28) are also missing. Seeing as **Content Lock** is the name of your package, I haven't translated that. And as I'm not sure in which context **Unlocker** is used, I've also skipped that one.