### PR TITLE
Localize the new dialog for content unlocked to do a refresh

### DIFF
--- a/ContentLock/Client/src/localizations/cy.ts
+++ b/ContentLock/Client/src/localizations/cy.ts
@@ -32,5 +32,10 @@
         modalHeader: 'Pwy sy\'n ar-lein?',
         listOfUsers: 'Defnyddwyr Ar-lein',
         youLabel: 'Ti',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };

--- a/ContentLock/Client/src/localizations/dk.ts
+++ b/ContentLock/Client/src/localizations/dk.ts
@@ -32,5 +32,10 @@ export default {
         modalHeader: 'Who\'s online?',
         listOfUsers: 'Online Users',
         youLabel: 'Du',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };

--- a/ContentLock/Client/src/localizations/en.ts
+++ b/ContentLock/Client/src/localizations/en.ts
@@ -32,5 +32,10 @@ export default {
         modalHeader: 'Who\'s online?',
         listOfUsers: 'Online Users',
         youLabel: 'You',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };

--- a/ContentLock/Client/src/localizations/fr.ts
+++ b/ContentLock/Client/src/localizations/fr.ts
@@ -32,5 +32,10 @@ export default {
         modalHeader: 'Qui est en ligne',
         listOfUsers: 'Utilisateurs en ligne',
         youLabel: 'Toi',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };

--- a/ContentLock/Client/src/localizations/it.ts
+++ b/ContentLock/Client/src/localizations/it.ts
@@ -32,6 +32,11 @@ export default {
         modalHeader: 'Who\'s online?',
         listOfUsers: 'Online Users',
         youLabel: 'Voi',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };
  

--- a/ContentLock/Client/src/localizations/nl.ts
+++ b/ContentLock/Client/src/localizations/nl.ts
@@ -32,5 +32,10 @@ export default {
         modalHeader: 'Wie is online?',
         listOfUsers: 'Online Gebruikers',
         youLabel: 'Jij',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };

--- a/ContentLock/Client/src/localizations/no.ts
+++ b/ContentLock/Client/src/localizations/no.ts
@@ -32,5 +32,10 @@ export default {
         modalHeader: 'Hvem er online?',
         listOfUsers: 'Online brukere',
         youLabel: 'Du',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };

--- a/ContentLock/Client/src/localizations/readme.md
+++ b/ContentLock/Client/src/localizations/readme.md
@@ -59,6 +59,11 @@ https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-custom-dashboard/addin
 | contentLockUsersModal.listOfUsers        | Online Users                                                         |
 | contentLockUsersModal.youLabel           | You                                                                  |
 
+|  Key                                     | Value                                                                                                                                                      |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| contentUnlockedModal.modalHeader         | Content Unlocked                                                                                                                                           |
+| contentUnlockedModal.modalContent        | The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version |
+| contentUnlockedModal.reload              | Reload                                                                                                                                                     |
 
 ### en.ts
 ```ts
@@ -96,6 +101,11 @@ export default {
         modalHeader: 'Who\'s online?',
         listOfUsers: 'Online Users',
         youLabel: 'You',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };
 ```

--- a/ContentLock/Client/src/localizations/tr.ts
+++ b/ContentLock/Client/src/localizations/tr.ts
@@ -32,5 +32,10 @@ export default {
         modalHeader: 'Kimler çevrimiçi?',
         listOfUsers: 'Çevrimiçi Kullanıcılar',
         youLabel: 'Sen',
+    },
+    contentUnlockedModal: {
+        modalHeader: 'Content Unlocked',
+        modalContent: 'The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version',
+        reload: 'Reload',
     }
 };

--- a/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
+++ b/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
@@ -8,6 +8,7 @@ import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import ContentLockSignalrContext, { CONTENTLOCK_SIGNALR_CONTEXT } from '../globalContexts/contentlock.signalr.context';
 import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
 import { UMB_CONFIRM_MODAL, umbOpenModal } from '@umbraco-cms/backoffice/modal';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 export class ContentLockWorkspaceContext extends UmbContextBase {
 
@@ -27,6 +28,8 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
     #signalRContext?: ContentLockSignalrContext;
 
     #currentUserKey?: string;
+
+    #localize = new UmbLocalizationController(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, CONTENTLOCK_WORKSPACE_CONTEXT.toString());
@@ -108,10 +111,10 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                     umbOpenModal(this, UMB_CONFIRM_MODAL,
                         {
                             data: {
-                                headline: "Content Unlocked",
-                                content: "The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version",
+                                headline: this.#localize.term('contentUnlockedModal_modalHeader'),
+                                content: this.#localize.term('contentUnlockedModal_modalContent'),
                                 color: "positive",
-                                confirmLabel: "Reload",
+                                confirmLabel: this.#localize.term('contentUnlockedModal_reload'),
                             }
                         }
                     )


### PR DESCRIPTION
Fixes https://github.com/warrenbuckley/Umbraco.Community.ContentLock/issues/39

### New Translations

|  Key                                     | Value                                                                                                                                                      |
|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
| contentUnlockedModal.modalHeader         | Content Unlocked                                                                                                                                           |
| contentUnlockedModal.modalContent        | The content is now unlocked and available for editing, however it may have been modified by another user. Please reload the page to see the latest version |
| contentUnlockedModal.reload              | Reload                                                                                                                                                     |

## UI for context
This dialog appears when you are viewing a node that is locked but becomes unlocked whilst you are on the node.
Where it prompts you to reload the node to see if any new changes that may have taken place.

<img width="960" alt="image" src="https://github.com/user-attachments/assets/06766c6d-6495-43a1-8a74-b73acc8d8c5b" />

