### PR TITLE
Entity Actions now work from the tree

### DIFF
--- a/ContentLock/Client/src/conditions/ShowLock.Condition.ts
+++ b/ContentLock/Client/src/conditions/ShowLock.Condition.ts
@@ -1,27 +1,41 @@
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbConditionConfigBase, UmbConditionControllerArguments, UmbExtensionCondition } from "@umbraco-cms/backoffice/extension-api";
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import { CONTENTLOCK_WORKSPACE_CONTEXT } from '../workspaceContexts/contentlock.workspace.context';
+import { CONTENTLOCK_SIGNALR_CONTEXT } from '../globalContexts/contentlock.signalr.context';
+import { UMB_ENTITY_CONTEXT, UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
  
 export default class ShowLockCondition extends UmbConditionBase<UmbConditionConfigBase> implements UmbExtensionCondition
 {
+    #unique?: UmbEntityUnique;
+
     constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<UmbConditionConfigBase>) {
         super(host, args);
 
-        this.consumeContext(CONTENTLOCK_WORKSPACE_CONTEXT , (contentLockWorkspaceCtx) => {
-            if (!contentLockWorkspaceCtx) {
-                console.warn('Content Lock Workspace Context is not available');
+        this.consumeContext(UMB_ENTITY_CONTEXT,(entityCtx) => {
+            this.observe(entityCtx?.unique, (unique) => {
+                this.#unique = unique;
+            });
+        });
+
+        this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT , (signalRCtx) => {
+            if (!signalRCtx) {
+                console.warn('SignalR context is not available.');
                 return;
             }
 
-            this.observe(contentLockWorkspaceCtx?.isLocked, (isLocked) => {
-                if(!isLocked){
-                    // Node is NOT locked - show the lock action
-                    this.permitted = true;
+            if(!this.#unique) {
+                console.warn('Entity unique is not available.');
+                return;
+            }
+            
+            this.observe(signalRCtx.isNodeLocked(this.#unique?.toString()) , (isNodeLocked) => {
+                if(isNodeLocked){
+                    // Node is already locked - hide the lock action
+                    this.permitted = false;
                 }
                 else {
-                    // Otherwise we hide/remove it
-                    this.permitted = false;
+                    // Otherwise we show it
+                    this.permitted = true;
                 }
             });
         });

--- a/ContentLock/Client/src/conditions/ShowUnlock.Condition.ts
+++ b/ContentLock/Client/src/conditions/ShowUnlock.Condition.ts
@@ -1,22 +1,49 @@
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbConditionConfigBase, UmbConditionControllerArguments, UmbExtensionCondition } from "@umbraco-cms/backoffice/extension-api";
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import { CONTENTLOCK_WORKSPACE_CONTEXT } from '../workspaceContexts/contentlock.workspace.context';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
+import { UMB_ENTITY_CONTEXT, UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
+import { CONTENTLOCK_SIGNALR_CONTEXT } from '../globalContexts/contentlock.signalr.context';
+import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
  
 export default class ShowUnlockCondition extends UmbConditionBase<UmbConditionConfigBase> implements UmbExtensionCondition
 {
+    #documentUnique?: UmbEntityUnique;
+    #currentUser?: string;
+
     constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<UmbConditionConfigBase>) {
         super(host, args);
 
-        this.consumeContext(CONTENTLOCK_WORKSPACE_CONTEXT , (contentLockWorkspaceCtx) => {
-            if (!contentLockWorkspaceCtx) {
-                console.warn('Content Lock Workspace Context is not available');
+        this.consumeContext(UMB_ENTITY_CONTEXT,(entityCtx) => {
+            this.observe(entityCtx?.unique, (unique) => {
+                this.#documentUnique = unique;
+            });
+        });
+
+        this.consumeContext(UMB_CURRENT_USER_CONTEXT,(currentUserCtx) => {
+            this.observe(currentUserCtx?.unique, (currentUserUnique) => {
+                this.#currentUser = currentUserUnique;
+            });
+        });
+
+        this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT , (signalRCtx) => {
+            if (!signalRCtx) {
+                console.warn('SignalR context is not available.');
                 return;
             }
 
-            this.observe(observeMultiple([contentLockWorkspaceCtx?.isLocked, contentLockWorkspaceCtx?.isLockedBySelf,]),([isLocked, isLockedBySelf]) => {
-                if(isLocked && isLockedBySelf){
+            if(!this.#documentUnique) {
+                console.warn('Entity unique is not available.');
+                return;
+            }
+
+            if(!this.#currentUser) {
+                console.warn('Current User unique is not available.');
+                return;
+            }
+
+            this.observe(observeMultiple([signalRCtx.isNodeLocked(this.#documentUnique?.toString()), signalRCtx.isNodeLockedByMe(this.#documentUnique?.toString(), this.#currentUser)]), ([isNodeLocked, isLockedBySelf]) => {
+                if(isNodeLocked && isLockedBySelf){
                     // Node is locked by self - show the unlock action
                     this.permitted = true;
                 }


### PR DESCRIPTION
Fixes https://github.com/warrenbuckley/Umbraco.Community.ContentLock/issues/38

## Problem
The Lock and Unlock entity actions was not appearing from the tree

## Fix
This was because the ContentLockWorkspace CTX is not in available in the tree, so to fix the problem was to use the global SignalR context instead.