### PR TITLE
Chore: Change to propertyWriteGuard & fix/workaround for node name not showing readonly

### DIFF
--- a/ContentLock/Client/src/conditions/CanShowCommonActions.Condition.ts
+++ b/ContentLock/Client/src/conditions/CanShowCommonActions.Condition.ts
@@ -42,7 +42,6 @@ export default class CanShowCommonActionsCondition extends UmbConditionBase<UmbC
             }
 
             this.observe(signalrCtx?.userCanSeeCommonActions(this.#unique, this.#currentUserUnique), (canSeeCommonActions) => {
-                console.log('Can see common actions RESULT =', canSeeCommonActions);
                 this.permitted = canSeeCommonActions;
             });
         });

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -238,23 +238,18 @@ export default class ContentLockSignalrContext extends UmbContextBase
     }
 
     public userCanSeeCommonActions(nodeKey: string, currentUserKey: string) {
-        console.log(`userCanSeeCommonActions: Checking if user can see common actions for node ${nodeKey} and current user key ${currentUserKey}`);
-
         return observeMultiple([this.isNodeLocked(nodeKey), this.isNodeLockedByMe(nodeKey, currentUserKey)])
             .pipe(
                 debounceTime(20),
                 map(([isNodeLocked, isNodeLockedByMe]) => {
                     if (isNodeLocked && isNodeLockedByMe) {
                         // Node is locked and locked by the current user - show the actions
-                        console.log('userCanSeeCommonActions: Node is locked BUT its locked by the current user - show the actions');
                         return true;
                     } else if (isNodeLocked && !isNodeLockedByMe) {
                         // Node is locked by another user - hide the actions
-                        console.log('userCanSeeCommonActions: Node is locked by another user - hide the actions');
                         return false;
                     } else {
                         // Node is unlocked - show the actions
-                        console.log('userCanSeeCommonActions: Node is unlocked - show the actions');
                         return true;
                     }
                 })

--- a/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
+++ b/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
@@ -1,18 +1,20 @@
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UMB_DOCUMENT_WORKSPACE_CONTEXT, UmbDocumentWorkspaceContext } from '@umbraco-cms/backoffice/document';
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT, UmbDocumentVariantModel, UmbDocumentWorkspaceContext } from '@umbraco-cms/backoffice/document';
 import { observeMultiple, UmbBooleanState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
 import ContentLockSignalrContext, { CONTENTLOCK_SIGNALR_CONTEXT } from '../globalContexts/contentlock.signalr.context';
 import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
 import { UMB_CONFIRM_MODAL, umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 export class ContentLockWorkspaceContext extends UmbContextBase {
 
     #docWorkspaceCtx?: UmbDocumentWorkspaceContext;
     #unique: UmbEntityUnique | undefined;
+    #variants: UmbDocumentVariantModel[] = [];
   
     #isLocked = new UmbBooleanState(false);
     isLocked = this.#isLocked.asObservable();
@@ -47,8 +49,9 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
         this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (docWorkspaceCtx) => {
             this.#docWorkspaceCtx = docWorkspaceCtx;
 
-            this.#docWorkspaceCtx?.observe(this.#docWorkspaceCtx?.unique, (unique) => {
+            this.#docWorkspaceCtx?.observe(observeMultiple([this.#docWorkspaceCtx?.unique, this.#docWorkspaceCtx?.variants]), ([unique, variants]) => {
                 this.#unique = unique;
+                this.#variants = variants;
                 this.checkContentLockState();
             });
         });
@@ -86,10 +89,24 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                         permitted: false,
                         message: `This page is locked by ${lockInfo?.checkedOutBy}`
                     });
+
+                    // Set the read only state of the document for ALL culture & segment variant combinations
+                    // Even documents without a variant will have a default variant with the culture and segment set to null
+                    const rules = this.#variants.map(variant => ({
+                        unique: `${this.#unique!.toString()}-${variant.culture}`,
+                        variantId: new UmbVariantId(variant.culture, variant.segment),
+                        permitted: false,
+                        message: `This page is locked by ${lockInfo?.checkedOutBy}`
+                    }));
+                    this.#docWorkspaceCtx?.readOnlyGuard.addRules(rules);
                 }
                 else {
                     // Page is not locked or its locked by self - remove the readonly (propertyWriteGuard)
                     this.#docWorkspaceCtx?.propertyWriteGuard.removeRule(`ContentLock-${this.#unique!.toString()}`);
+
+                    // Same for the read only state of the document for ALL culture & segment variant combinations
+                    const ruleKeys = this.#variants.map(variant => `${this.#unique!.toString()}-${variant.culture}`);
+                    this.#docWorkspaceCtx?.readOnlyGuard.removeRules(ruleKeys);
                 }
 
                 // If previously the page was locked by someone else, we can alert the user its now unlocked

--- a/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
+++ b/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
@@ -203,7 +203,7 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                 return;
             }
 
-            var umbVariant = new UmbVariantId(firstVariant.culture, firstVariant.segment);
+            const umbVariant = new UmbVariantId(firstVariant.culture, firstVariant.segment);
             this.#docWorkspaceCtx?.setName(currentName + '1', umbVariant);
             this.#docWorkspaceCtx?.setName(currentName, umbVariant);
 

--- a/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
+++ b/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
@@ -112,6 +112,7 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                 }
 
                 // TODO: Remember to remove this once PR merged in
+                // TODO: Remove this once we do a V17 targeted release
                 // https://github.com/umbraco/Umbraco-CMS/pull/19621
                 // Call the MEGA HACK workaround in a separate method
                 // ================================================================
@@ -176,6 +177,7 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
     // ================================================================================================
     /**
      * TODO: REMEMBER TO REMOVE THIS
+     * TODO: Remove this once we do a V17 targeted release
      * Temporary workaround for Umbraco bug see https://github.com/umbraco/Umbraco-CMS/pull/19621
      * Forces the workspace name to update to avoid UI issues when unlocking.
      * Thanks to Mads for the idea/hack for now

--- a/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
+++ b/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
@@ -95,7 +95,7 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                     const rules = this.#variants.map(variant => ({
                         unique: `${this.#unique!.toString()}-${variant.culture}`,
                         variantId: new UmbVariantId(variant.culture, variant.segment),
-                        permitted: false,
+                        permitted: true, // This seems really weird and backwards to me
                         message: `This page is locked by ${lockInfo?.checkedOutBy}`
                     }));
                     this.#docWorkspaceCtx?.readOnlyGuard.addRules(rules);

--- a/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
+++ b/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
@@ -1,10 +1,9 @@
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UMB_DOCUMENT_WORKSPACE_CONTEXT, UmbDocumentVariantModel, UmbDocumentWorkspaceContext } from '@umbraco-cms/backoffice/document';
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT, UmbDocumentWorkspaceContext } from '@umbraco-cms/backoffice/document';
 import { observeMultiple, UmbBooleanState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
-import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import ContentLockSignalrContext, { CONTENTLOCK_SIGNALR_CONTEXT } from '../globalContexts/contentlock.signalr.context';
 import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
 import { UMB_CONFIRM_MODAL, umbOpenModal } from '@umbraco-cms/backoffice/modal';
@@ -14,7 +13,6 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
 
     #docWorkspaceCtx?: UmbDocumentWorkspaceContext;
     #unique: UmbEntityUnique | undefined;
-    #variants: UmbDocumentVariantModel[] = [];
   
     #isLocked = new UmbBooleanState(false);
     isLocked = this.#isLocked.asObservable();
@@ -49,10 +47,8 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
         this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (docWorkspaceCtx) => {
             this.#docWorkspaceCtx = docWorkspaceCtx;
 
-            this.#docWorkspaceCtx?.observe(observeMultiple([this.#docWorkspaceCtx?.unique, this.#docWorkspaceCtx?.variants]), ([unique, variants]) => {
+            this.#docWorkspaceCtx?.observe(this.#docWorkspaceCtx?.unique, (unique) => {
                 this.#unique = unique;
-                this.#variants = variants;
-
                 this.checkContentLockState();
             });
         });
@@ -83,27 +79,17 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                     this.setLockedByName(lockInfo.checkedOutBy);
                 }
 
-                // Clear out any existing readonly states first
-                // Added: As was seeing issues that it was reporting the state with the same unique was already added
-                this.#docWorkspaceCtx?.readOnlyGuard.clearRules();
-
                 if(isLocked && isLockedBySelf === false){
-                    // Page is locked by someone else - set the readonly state/readonly guard
-                    // Set the read only state of the document for ALL culture & segment variant combinations
-                    // Even documents without a variant will have a default variant with the culture and segment set to null
-                    this.#variants.forEach(async variant => {
-                        await this.#docWorkspaceCtx?.readOnlyGuard.addRule({
-                            unique: `${this.#unique!.toString()}-${variant.culture}`,
-                            variantId: new UmbVariantId(variant.culture, variant.segment),
-                            message: `This page is locked by ${lockInfo?.checkedOutBy}`
-                        });
+                    // Page is locked by someone else - set the propertyWriteGuard
+                    this.#docWorkspaceCtx?.propertyWriteGuard.addRule({
+                        unique: `ContentLock-${this.#unique!.toString()}`,
+                        permitted: false,
+                        message: `This page is locked by ${lockInfo?.checkedOutBy}`
                     });
                 }
                 else {
-                    // Page is not locked or its locked by self - remove the readonly state
-                    this.#variants.forEach(async variant => {
-                        await this.#docWorkspaceCtx?.readOnlyGuard.removeRule(`${this.#unique!.toString()}-${variant.culture}`);
-                    });
+                    // Page is not locked or its locked by self - remove the readonly (propertyWriteGuard)
+                    this.#docWorkspaceCtx?.propertyWriteGuard.removeRule(`ContentLock-${this.#unique!.toString()}`);
                 }
 
                 // If previously the page was locked by someone else, we can alert the user its now unlocked

--- a/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
+++ b/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
@@ -31,6 +31,8 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
 
     #localize = new UmbLocalizationController(this);
 
+    #isSettingNameHack = false;
+
 	constructor(host: UmbControllerHost) {
 		super(host, CONTENTLOCK_WORKSPACE_CONTEXT.toString());
 
@@ -109,6 +111,14 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                     this.#docWorkspaceCtx?.readOnlyGuard.removeRules(ruleKeys);
                 }
 
+                // TODO: Remember to remove this once PR merged in
+                // https://github.com/umbraco/Umbraco-CMS/pull/19621
+                // Call the MEGA HACK workaround in a separate method
+                // ================================================================
+                this.#runSetNameHack();
+                // ================================================================
+
+
                 // If previously the page was locked by someone else, we can alert the user its now unlocked
                 if (previousState.isLocked && !previousState.isLockedBySelf && !isLocked && !isLockedBySelf) {
                     umbOpenModal(this, UMB_CONFIRM_MODAL,
@@ -162,6 +172,44 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
 	public setLockedByName(lockedBy: string) {
 		this.#lockedByName.setValue(lockedBy);
 	}
+
+    // ================================================================================================
+    /**
+     * TODO: REMEMBER TO REMOVE THIS
+     * Temporary workaround for Umbraco bug see https://github.com/umbraco/Umbraco-CMS/pull/19621
+     * Forces the workspace name to update to avoid UI issues when unlocking.
+     * Thanks to Mads for the idea/hack for now
+     */
+    #runSetNameHack() {
+        if (this.#isSettingNameHack){
+            return;
+        }
+
+        this.#isSettingNameHack = true;
+        
+        try {
+            const currentName = this.#docWorkspaceCtx?.getName();
+            if (!currentName) {
+                this.#isSettingNameHack = false;
+                return;
+            }
+
+            // Even if the node does not vary with languages or segments its still gives us one variant
+            const firstVariant = this.#variants[0];
+            if(!firstVariant) {
+                this.#isSettingNameHack = false;
+                return;
+            }
+
+            var umbVariant = new UmbVariantId(firstVariant.culture, firstVariant.segment);
+            this.#docWorkspaceCtx?.setName(currentName + '1', umbVariant);
+            this.#docWorkspaceCtx?.setName(currentName, umbVariant);
+
+        } finally {
+            this.#isSettingNameHack = false;
+        }
+    }
+    // ================================================================================
 }
 
 // Declare a api export, so Extension Registry can initialize this class:


### PR DESCRIPTION
Fixes #43 

## Umbraco Docs
https://docs.umbraco.com/umbraco-cms/customizing/property-level-ui-permissions#write-a-general-rule

## Another example/usecase
https://github.com/nielslyngsoe/cg25-umbrago-next-level-backoffice/blob/main/CG25NextLevelBackoffice/Client/src/property-permissions/property-permissions-setter.ts

---

## Notes
In 16.0.0 its recommended to use `propertyWriteGuard` to mark properties as readonly, however this does not take into account the document/node name like before.

Docs say that you should not use `readOnlyGuard` but Umbraco is still using this internally and chatting with @madsrasmussen its OK to still carry on using it for now.

But when working with it, it would still freak out for me and only when I change the variant in the dropdown selector for the node name then the readonly note on the node name/variant would display correctly.

This is a bug and being fixed in this PR
https://github.com/umbraco/Umbraco-CMS/pull/19621

However with some lovely friendly advice for Mads, there is an interesting/ugly hack workaround for now that makes this work as intended.

> [!WARNING]
> I just need to remove the hack once the PR above is merged and 16.1.0 is released