### PR TITLE
Chore/tackle warning obsoletes

### DIFF
--- a/ContentLock/Migrations/v1/AddUserPermissionToAdmins.cs
+++ b/ContentLock/Migrations/v1/AddUserPermissionToAdmins.cs
@@ -10,7 +10,7 @@ using Umbraco.Cms.Infrastructure.Packaging;
 
 namespace ContentLock.Migrations.v1
 {
-    public class AddUserPermissionToAdmins : PackageMigrationBase
+    public class AddUserPermissionToAdmins : AsyncPackageMigrationBase
     {
         private readonly IUserGroupService _userGroupService;
         private readonly ILogger<AddUserPermissionToAdmins> _logger;
@@ -40,25 +40,23 @@ namespace ContentLock.Migrations.v1
             _logger = logger;
         }
 
-        protected override void Migrate()
+        protected override async Task MigrateAsync()
         {
-            // Booo :( the Migrate from PackageMigrationBase does not support Async
-            var adminGroup = _userGroupService.GetAsync(Umbraco.Cms.Core.Constants.Security.AdminGroupKey).Result;
-
+            var adminGroup = await _userGroupService.GetAsync(Umbraco.Cms.Core.Constants.Security.AdminGroupKey);
             if (adminGroup == null)
             {
                 _logger.LogWarning("ContentLock is unable to find the default Umbraco Admin User Group. Exiting");
                 return;
             }
 
-            // Permissions ?!
+            // Existing permissions are already set, so we can just add the new permission
             var permissions = adminGroup.Permissions;
 
             // Add new permission (Same as the permission verb in clientside code)
             permissions.Add(Constants.Permission);
 
             // Update the user group
-            var attempt = _userGroupService.UpdateAsync(adminGroup, Umbraco.Cms.Core.Constants.Security.SuperUserKey).Result;
+            var attempt = await _userGroupService.UpdateAsync(adminGroup, Umbraco.Cms.Core.Constants.Security.SuperUserKey);
 
             _logger.LogTrace("Updated default Umbraco Admin User Group with the 'ContentLock.Enabled' permission with this attempt status {status}", attempt.Status);
 

--- a/ContentLock/Migrations/v1/InitDatabaseTable.cs
+++ b/ContentLock/Migrations/v1/InitDatabaseTable.cs
@@ -10,7 +10,7 @@ using Umbraco.Cms.Infrastructure.Packaging;
 
 namespace ContentLock.Migrations.v1
 {
-    public class InitDatabaseTable : PackageMigrationBase
+    public class InitDatabaseTable : AsyncPackageMigrationBase
     {
         public InitDatabaseTable(
             IPackagingService packagingService,
@@ -33,12 +33,14 @@ namespace ContentLock.Migrations.v1
         {
         }
 
-        protected override void Migrate()
+        protected override Task MigrateAsync()
         {
             if (TableExists(ContentLocks.TableName) is false)
             {
                 Create.Table<ContentLocks>().Do();
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/ContentLock/SignalR/ContentLockHubRoutes.cs
+++ b/ContentLock/SignalR/ContentLockHubRoutes.cs
@@ -1,25 +1,18 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Hosting;
+
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.Routing;
-using Umbraco.Extensions;
 
 namespace ContentLock.SignalR;
 
 public class ContentLockHubRoutes : IAreaRoutes
 {
     private readonly IRuntimeState _runtimeState;
-    private readonly string _umbracoPathSegment;
 
-    public ContentLockHubRoutes(IOptions<GlobalSettings> globalSettings,
-        IHostingEnvironment hostingEnvironment,
-        IRuntimeState runtimeState)
+    public ContentLockHubRoutes(IRuntimeState runtimeState)
     {
         _runtimeState = runtimeState;
-        _umbracoPathSegment = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
     }
     
     public void CreateRoutes(IEndpointRouteBuilder endpoints)
@@ -34,6 +27,6 @@ public class ContentLockHubRoutes : IAreaRoutes
     
     public string GetContentLockHubRoute()
     {
-        return $"/{_umbracoPathSegment}/{nameof(ContentLockHub)}";
+        return $"/{Umbraco.Cms.Core.Constants.System.UmbracoPathSegment}/{nameof(ContentLockHub)}";
     }
 }


### PR DESCRIPTION
Fixes #53 

## Obsolete Warnings

* `PackageMigrationBase` is obsolete: 'Use `AsyncPackageMigrationBase` instead. Scheduled for removal in Umbraco 18.'

* `GlobalSettingsExtensions.GetUmbracoMvcArea(GlobalSettings, IHostingEnvironment)` is obsolete: 'The UmbracoPath setting is removed, use `Constants.System.UmbracoPathSegment` as area name instead. Scheduled for removal in Umbraco 17.'