### PR TITLE
Minor Cleanup

### DIFF
--- a/ContentLock/Controllers/ContentLockApiController.cs
+++ b/ContentLock/Controllers/ContentLockApiController.cs
@@ -73,7 +73,6 @@ namespace ContentLock.Controllers
             var currentUser = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
             var userKey = currentUser?.Key;
             var userLang = currentUser?.Language ?? "en";
-            var userName = currentUser?.Name ?? "Unknown person";
             var cultureInfo = new CultureInfo(userLang);
 
             // Get current info for lock

--- a/ContentLock/Interfaces/IContentLockHubEvents.cs
+++ b/ContentLock/Interfaces/IContentLockHubEvents.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using ContentLock.Models.Backoffice;
 using ContentLock.Options;
 

--- a/ContentLock/Interfaces/IContentLockService.cs
+++ b/ContentLock/Interfaces/IContentLockService.cs
@@ -7,7 +7,7 @@ namespace ContentLock.Interfaces
         /// <summary>
         /// Lock a content node with a given user
         /// </summary>
-        /// <param name="key">The content node key to lock</param>
+        /// <param name="contentKey">The content node key to lock</param>
         /// <param name="userKey">The user key, requesting to lock the node</param>
         Task<ContentLockOverviewItem> LockContentAsync(Guid contentKey, Guid userKey);
 

--- a/ContentLock/Migrations/v1/AddUserPermissionToAdmins.cs
+++ b/ContentLock/Migrations/v1/AddUserPermissionToAdmins.cs
@@ -24,7 +24,6 @@ namespace ContentLock.Migrations.v1
             IMigrationContext context,
             IOptions<PackageMigrationSettings> packageMigrationsSettings,
             IUserGroupService userGroupService,
-            IUserService userService,
             ILogger<AddUserPermissionToAdmins> logger)
             : base(
                   packagingService,

--- a/ContentLock/Options/ContentLockOptions.cs
+++ b/ContentLock/Options/ContentLockOptions.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Logging;
-
 namespace ContentLock.Options;
 
 public class ContentLockOptions


### PR DESCRIPTION
This pull request includes several minor changes across multiple files in the `ContentLock` project, primarily focusing on cleanup, naming adjustments, and removal of unused code. Below is a categorized summary of the most important changes:

### Code Cleanup:
* Removed unused `using System.Collections.Concurrent` directive in `ContentLock/Interfaces/IContentLockHubEvents.cs`.
* Removed unused `using Microsoft.Extensions.Logging` directive in `ContentLock/Options/ContentLockOptions.cs`.
* Removed the `IUserService` parameter from the constructor of `AddUserPermissionToAdmins` in `ContentLock/Migrations/v1/AddUserPermissionToAdmins.cs`.

### Naming Adjustments:
* Renamed parameter `key` to `contentKey` in the `LockContentAsync` method of `IContentLockService` to improve clarity.

### Minor Code Simplification:
* Removed fallback assignment for `userName` in `UnlockContentAsync` method in `ContentLock/Controllers/ContentLockApiController.cs` as it was unused.