### PR TITLE
Fixup notifications not appearing from entity actions Lock/Unlock

### DIFF
--- a/ContentLock/Client/src/entityActions/lock.document.entityaction.ts
+++ b/ContentLock/Client/src/entityActions/lock.document.entityaction.ts
@@ -15,8 +15,7 @@ export class LockDocumentEntityAction extends UmbEntityActionBase<never> {
     constructor(host: UmbControllerHost, args: UmbEntityActionArgs<never>) {
         super(host, args);
 
-        // Fetch/consume the contexts & assign to the private fields
-        this.consumeContext(UMB_NOTIFICATION_CONTEXT, (notificationCtx) => {
+        this.getContext(UMB_NOTIFICATION_CONTEXT).then((notificationCtx) => {
             this.#notificationCtx = notificationCtx;
         });
     }

--- a/ContentLock/Client/src/entityActions/manifest.ts
+++ b/ContentLock/Client/src/entityActions/manifest.ts
@@ -11,7 +11,7 @@ export const manifests: Array<UmbExtensionManifest> = [
     type: 'entityAction',
     kind: 'default',
     api: LockDocumentEntityAction,
-    weight: 400,
+    weight: 401,
     meta: {
       label: 'Lock Document',
       icon: 'icon-combination-lock',

--- a/ContentLock/Client/src/entityActions/unlock.document.entityaction.ts
+++ b/ContentLock/Client/src/entityActions/unlock.document.entityaction.ts
@@ -15,8 +15,7 @@ export class UnlockDocumentEntityAction extends UmbEntityActionBase<never> {
     constructor(host: UmbControllerHost, args: UmbEntityActionArgs<never>) {
         super(host, args);
 
-        // Fetch/consume the contexts & assign to the private fields
-        this.consumeContext(UMB_NOTIFICATION_CONTEXT, (notificationCtx) => {
+        this.getContext(UMB_NOTIFICATION_CONTEXT).then((notificationCtx) => {
             this.#notificationCtx = notificationCtx;
         });
     }


### PR DESCRIPTION
Not sure why but consuming the NotificationContext no longer works, resolved by getting a one time instance of the context every time the action is run.

----

This pull request introduces changes to improve how context is fetched in entity actions and adjusts the manifest configuration for the `LockDocumentEntityAction`. The most important changes include replacing the `consumeContext` method with `getContext` for asynchronous context retrieval and updating the manifest weight for the lock document action.

### Improvements to context fetching:

* [`ContentLock/Client/src/entityActions/lock.document.entityaction.ts`](diffhunk://#diff-95bea8e0d961286e82182c7fb9d069376cd91a9a349dec05232167d1b5af20a8L18-R18): Replaced `consumeContext` with `getContext` to fetch the `UMB_NOTIFICATION_CONTEXT` asynchronously in the `LockDocumentEntityAction` class.
* [`ContentLock/Client/src/entityActions/unlock.document.entityaction.ts`](diffhunk://#diff-fc1807a443a46f254c7cfa6042edda03a4e14aea4bd72249762c316ac9f1393eL18-R18): Replaced `consumeContext` with `getContext` to fetch the `UMB_NOTIFICATION_CONTEXT` asynchronously in the `UnlockDocumentEntityAction` class.

### Manifest configuration updates:

* [`ContentLock/Client/src/entityActions/manifest.ts`](diffhunk://#diff-55eae4fbf38d173c492ccd4f0926e4c496edd2687427b70b1f87239e2d6e8ff1L14-R14): Increased the `weight` of the `LockDocumentEntityAction` manifest from 400 to 401.