### PR TITLE
Fixes & improves observers needed for CanShowCommonActions condition

### DIFF
--- a/ContentLock/Client/src/conditions/CanShowCommonActions.Condition.ts
+++ b/ContentLock/Client/src/conditions/CanShowCommonActions.Condition.ts
@@ -1,50 +1,73 @@
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbConditionConfigBase, UmbConditionControllerArguments, UmbExtensionCondition } from "@umbraco-cms/backoffice/extension-api";
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import { UMB_ENTITY_CONTEXT, UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
-import { CONTENTLOCK_SIGNALR_CONTEXT } from '../globalContexts/contentlock.signalr.context';
-import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
+import { UMB_ENTITY_CONTEXT, UmbEntityContext } from '@umbraco-cms/backoffice/entity';
+import ContentLockSignalrContext, { CONTENTLOCK_SIGNALR_CONTEXT } from '../globalContexts/contentlock.signalr.context';
+import { UMB_CURRENT_USER_CONTEXT, UmbCurrentUserContext } from '@umbraco-cms/backoffice/current-user';
+import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
+import { filter, switchMap } from '@umbraco-cms/backoffice/external/rxjs';
 
 export default class CanShowCommonActionsCondition extends UmbConditionBase<UmbConditionConfigBase> implements UmbExtensionCondition
 {
-    #unique?: UmbEntityUnique;
-    #currentUserUnique?: string;
+    #entityCtx?: UmbEntityContext;
+    #currentUserCtx?: UmbCurrentUserContext;
+    #signalrCtx?: ContentLockSignalrContext;
 
     constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<UmbConditionConfigBase>) {
         super(host, args);
 
         this.consumeContext(UMB_ENTITY_CONTEXT, (entityCtx) => {
-            this.observe(entityCtx?.unique, (unique) => {
-                this.#unique = unique;
-            });
+            // Store the reference to the context
+            this.#entityCtx = entityCtx;
+
+            // Try to setup observers each time a context is set
+            this.trySetupObservers();
         });
 
         this.consumeContext(UMB_CURRENT_USER_CONTEXT, (currentUserCtx) => {
-            this.observe(currentUserCtx?.currentUser, (currentUser) => {
-                this.#currentUserUnique = currentUser?.unique;
-            });
+            // Store the reference to the context
+            this.#currentUserCtx = currentUserCtx;
+
+            // Try to setup observers each time a context is set
+            this.trySetupObservers();
         });
 
         this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT, (signalrCtx) => {
-            if(!this.#unique) {
-                console.warn('Unique identifier of document is not available for SignalR context');
-                return;
-            }
+            // Store the reference to the context
+            this.#signalrCtx = signalrCtx;
 
-            if(!this.#currentUserUnique) {
-                console.warn('Current User Unique identifier is not available for SignalR context');
-                return;
-            }
-
-            if (!signalrCtx) {
-                console.warn('Content Lock SignalR Context is not available');
-                return;
-            }
-
-            this.observe(signalrCtx?.userCanSeeCommonActions(this.#unique, this.#currentUserUnique), (canSeeCommonActions) => {
-                this.permitted = canSeeCommonActions;
-            });
+            // Try to setup observers each time a context is set
+            this.trySetupObservers();
         });
+    }
+
+    trySetupObservers(): void {
+        // Only setup observation when all contexts are available to use
+        if (!this.#entityCtx || !this.#currentUserCtx || !this.#signalrCtx) {
+            return;
+        }
+
+         this.observe(
+            observeMultiple([
+                this.#entityCtx?.unique,
+                this.#currentUserCtx?.unique
+            ]).pipe(
+                // Filter out observable values being emitted where either value is undefined
+                // No point in checking permissions if we don't have BOTH values
+                filter(([documentUnique, currentUserUnique]) => !!documentUnique && !!currentUserUnique),
+                    
+                // switchMap takes the [documentUnique, currentUserUnique] pair and creates a NEW observable
+                switchMap(([documentUnique, currentUserUnique]) => {
+                    // This will return a NEW observable that watches for permission changes
+                    return this.#signalrCtx!.userCanSeeCommonActions(documentUnique!, currentUserUnique!);
+                })
+            ),
+            (canSeeCommonActions) => {
+                // The final observable value from the switchMap - userCanSeeCommonActions
+                this.permitted = canSeeCommonActions;
+            },
+            '_canShowCommonActionsConditionObserver' // Added an alias to the observer - The observer alias is meant to overwrite the subscription if a new context arrives
+        );
     }
 }
 


### PR DESCRIPTION
## Fixes
This fixes bug #70 

## Details
Fixes an issue where the entity context might not have yet been ready before the ContentLock Signalr one is consumed that it depends upon other observable values

## Forum Post reference
https://forum.umbraco.com/t/consuming-multiple-observables-from-different-contexts-before-using-in-method/6312