### PR TITLE
Add Umbraco Flag Provider

### DIFF
--- a/ContentLock/Client/src/bundle.manifests.ts
+++ b/ContentLock/Client/src/bundle.manifests.ts
@@ -10,6 +10,7 @@ import { manifests as userPermissions } from './userpermissions/manifest';
 import { manifests as workspaceActions } from './workspaceActions/manifest';
 import { manifests as workspaceContexts } from './workspaceContexts/manifest';
 import { manifests as workspaceFooterApps } from './workspaceFooterApp/manifest';
+import { manifests as entitySigns } from './entitySigns/manifest';
 
 // Job of the bundle is to collate all the manifests from different parts of the extension and load other manifests
 // We load this bundle from umbraco-package.json
@@ -26,4 +27,5 @@ export const manifests: Array<UmbExtensionManifest> = [
   ...workspaceActions,
   ...workspaceContexts,
   ...workspaceFooterApps,
+  ...entitySigns,
 ];

--- a/ContentLock/Client/src/entitySigns/manifest.ts
+++ b/ContentLock/Client/src/entitySigns/manifest.ts
@@ -1,0 +1,18 @@
+import { UMB_DOCUMENT_ENTITY_TYPE } from "@umbraco-cms/backoffice/document";
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+        name: '[Content Lock] Is Locked Document Entity Sign',
+        alias: 'ContentLock.EntitySign.Document.IsLocked',
+		type: 'entitySign',
+		kind: 'icon',
+		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
+		forEntityFlags: ['Umb.ContentLock.Locked'],
+        weight: 2000,
+		meta: { 
+            iconName: 'icon-lock',
+			label: 'Content is Locked',
+			iconColorAlias: 'red',
+        },
+	},
+];

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -8,6 +8,9 @@ import { observeMultiple, UmbArrayState, UmbObjectState } from "@umbraco-cms/bac
 import { ContentLockOptions } from "../interfaces/ContentLockOptions";
 import { debounceTime, map } from "@umbraco-cms/backoffice/external/rxjs";
 import { SignalrLogger } from "./signalr.logger";
+import { UMB_ACTION_EVENT_CONTEXT, UmbActionEventContext } from "@umbraco-cms/backoffice/action";
+import { UmbRequestReloadStructureForEntityEvent } from "@umbraco-cms/backoffice/entity-action";
+import { UMB_DOCUMENT_ENTITY_TYPE } from "@umbraco-cms/backoffice/document";
 
 export default class ContentLockSignalrContext extends UmbContextBase
 {
@@ -93,6 +96,8 @@ export default class ContentLockSignalrContext extends UmbContextBase
             })
         );
 
+    #eventContext?: UmbActionEventContext;
+
     constructor(host: UmbControllerHost) {
         super(host, CONTENTLOCK_SIGNALR_CONTEXT);
 
@@ -115,6 +120,25 @@ export default class ContentLockSignalrContext extends UmbContextBase
 
             this.#startHub();
         });
+
+        // Action Event context - to notify about emitting event to trigger a tree reload
+        this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (eventContext) => {
+            this.#eventContext = eventContext;
+        });
+    }
+
+    /**
+     * Send out an event to request the tree to reload the item with the given key
+     * Will fetch item/s from server again and thus get the latest Locked Flag/Sign info
+     * @param key The GUID/Unique/key that got updated
+     */
+    #emitReloadTreeEvent(key:string){
+        this.#eventContext?.dispatchEvent(new UmbRequestReloadStructureForEntityEvent(
+            {
+                unique: key,
+                entityType: UMB_DOCUMENT_ENTITY_TYPE
+            }
+        ));
     }
 
     // Start the engines...
@@ -132,17 +156,29 @@ export default class ContentLockSignalrContext extends UmbContextBase
             // SignalR server will send out a 'AddLockToClients' when someone locks an item
             this.signalrConnection.on('AddLockToClients', (contentLockInfo: ContentLockOverviewItem) => {
                 this.#contentLocks.appendOne(contentLockInfo);
+
+                // Reload tree item - will fetch from server again and thus get the Locked Flag/Sign info
+                this.#emitReloadTreeEvent(contentLockInfo.key);
             });
 
             // SignalR server will send out a 'RemoveLockToClients' when someone removes an individual lock item
-            this.signalrConnection.on('RemoveLockToClients', (contentKey:String) => {
+            this.signalrConnection.on('RemoveLockToClients', (contentKey:string) => {
                 this.#contentLocks.removeOne(contentKey);
+
+                // Reload tree item - will fetch from server again and thus remove the Locked Flag/Sign info
+                this.#emitReloadTreeEvent(contentKey);
             });
 
             // SignalR server will send out a 'RemoveLocksToClients' when one or more locks are removed in bulk
             // This happens from the dashboard overview
-            this.signalrConnection.on('RemoveLocksToClients', (contentKeys:Array<String>) => {
+            this.signalrConnection.on('RemoveLocksToClients', (contentKeys:Array<string>) => {
                 this.#contentLocks.remove(contentKeys);
+
+                // Have to loop over as Umbraco does not have a way to send multiple keys in the event
+                for(const key of contentKeys){
+                    // Reload tree item - will fetch from server again and thus remove the Locked Flag/Sign info
+                    this.#emitReloadTreeEvent(key);
+                }
             });
 
             // Purely for E2E tests only SignalR server will send out a 'RemoveAllLocksToClients'

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -134,7 +134,7 @@ export default class ContentLockSignalrContext extends UmbContextBase
      */
     #emitReloadTreeEvent(key: string){
         if(this.#eventContext){
-            this.#eventContext?.dispatchEvent(new UmbRequestReloadStructureForEntityEvent(
+            this.#eventContext.dispatchEvent(new UmbRequestReloadStructureForEntityEvent(
                 {
                     unique: key,
                     entityType: UMB_DOCUMENT_ENTITY_TYPE

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -104,7 +104,7 @@ export default class ContentLockSignalrContext extends UmbContextBase
         // Need auth context to use the token to pass to SignalR hub
         this.consumeContext(UMB_AUTH_CONTEXT, async (authCtx) => {
             if (!authCtx) {
-                console.warn('Auth context is not available for SignalR connection');
+                console.warn('[Content Lock - SignalR Ctx] Auth context is not available for SignalR connection');
                 return;
             }
 
@@ -132,13 +132,18 @@ export default class ContentLockSignalrContext extends UmbContextBase
      * Will fetch item/s from server again and thus get the latest Locked Flag/Sign info
      * @param key The GUID/Unique/key that got updated
      */
-    #emitReloadTreeEvent(key:string){
-        this.#eventContext?.dispatchEvent(new UmbRequestReloadStructureForEntityEvent(
-            {
-                unique: key,
-                entityType: UMB_DOCUMENT_ENTITY_TYPE
-            }
-        ));
+    #emitReloadTreeEvent(key: string){
+        if(this.#eventContext){
+            this.#eventContext?.dispatchEvent(new UmbRequestReloadStructureForEntityEvent(
+                {
+                    unique: key,
+                    entityType: UMB_DOCUMENT_ENTITY_TYPE
+                }
+            ));
+        } else{
+            console.warn('[Content Lock - SignalR Ctx] Unable to dispatch reload event because UMB_ACTION_EVENT_CONTEXT is not available.');
+        }
+        
     }
 
     // Start the engines...

--- a/ContentLock/Composers/ContentLockFlagComposer.cs
+++ b/ContentLock/Composers/ContentLockFlagComposer.cs
@@ -1,0 +1,15 @@
+﻿using ContentLock.FlagProviders;
+
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Extensions;
+
+namespace ContentLock.Composers;
+
+public class ContentLockFlagComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.FlagProviders().Append<IsLockedFlagProvider>();
+    }
+}

--- a/ContentLock/FlagProviders/IsLockedFlagProvider.cs
+++ b/ContentLock/FlagProviders/IsLockedFlagProvider.cs
@@ -1,4 +1,8 @@
-﻿using Umbraco.Cms.Api.Management.Services.Flags;
+﻿using ContentLock.Interfaces;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Umbraco.Cms.Api.Management.Services.Flags;
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
@@ -7,7 +11,13 @@ using Umbraco.Cms.Api.Management.ViewModels.Tree;
 namespace ContentLock.FlagProviders;
 public class IsLockedFlagProvider : IFlagProvider
 {
+    public IsLockedFlagProvider(IServiceScopeFactory serviceScopeFactory)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+    }
+
     private const string Alias = Umbraco.Cms.Core.Constants.Conventions.Flags.Prefix + "ContentLock.Locked";
+    private readonly IServiceScopeFactory _serviceScopeFactory;
 
     // Indicate that this flag provider only provides flags for documents.
     public bool CanProvideFlags<TItem>()
@@ -19,10 +29,21 @@ public class IsLockedFlagProvider : IFlagProvider
     public async Task PopulateFlagsAsync<TItem>(IEnumerable<TItem> itemViewModels)
         where TItem : IHasFlags
     {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var contentLockService = scope.ServiceProvider.GetRequiredService<IContentLockService>();
+
+        // Get all locks currently in the site - once for performance
+        var allLocks = await contentLockService.GetLockOverviewAsync();
+        var lockedKeys = new HashSet<Guid>(allLocks.Items.Select(x => x.Key));
+
         foreach (TItem item in itemViewModels)
         {
-            // DEMO: Just add it to everything
-            item.AddFlag(Alias);
+            // IHasFlags exposes Id, so we can check it directly
+            // without casting or pattern matching to the diff models
+            if (lockedKeys.Contains(item.Id))
+            {
+                item.AddFlag(Alias);
+            }
         }
     }
 }

--- a/ContentLock/FlagProviders/IsLockedFlagProvider.cs
+++ b/ContentLock/FlagProviders/IsLockedFlagProvider.cs
@@ -29,12 +29,16 @@ public class IsLockedFlagProvider : IFlagProvider
     public async Task PopulateFlagsAsync<TItem>(IEnumerable<TItem> itemViewModels)
         where TItem : IHasFlags
     {
+        var keys = itemViewModels
+            .Select(x => x.Id)
+            .Where(id => id != Guid.Empty)
+            .ToHashSet();
+
+        if (keys.Count == 0) return;
+
         using var scope = _serviceScopeFactory.CreateScope();
         var contentLockService = scope.ServiceProvider.GetRequiredService<IContentLockService>();
-
-        // Get all locks currently in the site - once for performance
-        var allLocks = await contentLockService.GetLockOverviewAsync();
-        var lockedKeys = new HashSet<Guid>(allLocks.Items.Select(x => x.Key));
+        var lockedKeys = await contentLockService.GetLockedContentKeysAsync(keys);
 
         foreach (TItem item in itemViewModels)
         {

--- a/ContentLock/FlagProviders/IsLockedFlagProvider.cs
+++ b/ContentLock/FlagProviders/IsLockedFlagProvider.cs
@@ -40,14 +40,11 @@ public class IsLockedFlagProvider : IFlagProvider
         var contentLockService = scope.ServiceProvider.GetRequiredService<IContentLockService>();
         var lockedKeys = await contentLockService.GetLockedContentKeysAsync(keys);
 
-        foreach (TItem item in itemViewModels)
+        foreach (TItem item in itemViewModels.Where(item => lockedKeys.Contains(item.Id)))
         {
             // IHasFlags exposes Id, so we can check it directly
             // without casting or pattern matching to the diff models
-            if (lockedKeys.Contains(item.Id))
-            {
-                item.AddFlag(Alias);
-            }
+            item.AddFlag(Alias);
         }
     }
 }

--- a/ContentLock/FlagProviders/IsLockedFlagProvider.cs
+++ b/ContentLock/FlagProviders/IsLockedFlagProvider.cs
@@ -1,0 +1,28 @@
+﻿using Umbraco.Cms.Api.Management.Services.Flags;
+using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
+using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+
+namespace ContentLock.FlagProviders;
+public class IsLockedFlagProvider : IFlagProvider
+{
+    private const string Alias = Umbraco.Cms.Core.Constants.Conventions.Flags.Prefix + "ContentLock.Locked";
+
+    // Indicate that this flag provider only provides flags for documents.
+    public bool CanProvideFlags<TItem>()
+        where TItem : IHasFlags =>
+        typeof(TItem) == typeof(DocumentTreeItemResponseModel) ||
+        typeof(TItem) == typeof(DocumentCollectionResponseModel) ||
+        typeof(TItem) == typeof(DocumentItemResponseModel);
+
+    public async Task PopulateFlagsAsync<TItem>(IEnumerable<TItem> itemViewModels)
+        where TItem : IHasFlags
+    {
+        foreach (TItem item in itemViewModels)
+        {
+            // DEMO: Just add it to everything
+            item.AddFlag(Alias);
+        }
+    }
+}

--- a/ContentLock/Interfaces/IContentLockService.cs
+++ b/ContentLock/Interfaces/IContentLockService.cs
@@ -33,11 +33,12 @@ namespace ContentLock.Interfaces
         Task<ContentLockOverview> GetLockOverviewAsync();
 
         /// <summary>
-        /// This will return all locked content keys
-        /// Used in conjunction with FlagProvider to know if the 
+        /// Returns the subset of the provided content keys that are currently locked.
+        /// Used in conjunction with FlagProvider to determine which content nodes are locked.
         /// </summary>
+        /// <param name="keys">A set of content node keys to check for lock status.</param>
         /// <returns>
-        /// Only the returned list of keys are locked
+        /// Only the returned list of keys are locked.
         /// </returns>
         Task<IReadOnlySet<Guid>> GetLockedContentKeysAsync(IReadOnlySet<Guid> keys);
     }

--- a/ContentLock/Interfaces/IContentLockService.cs
+++ b/ContentLock/Interfaces/IContentLockService.cs
@@ -31,5 +31,14 @@ namespace ContentLock.Interfaces
         /// Used for the overview dashboard
         /// </summary>
         Task<ContentLockOverview> GetLockOverviewAsync();
+
+        /// <summary>
+        /// This will return all locked content keys
+        /// Used in conjunction with FlagProvider to know if the 
+        /// </summary>
+        /// <returns>
+        /// Only the returned list of keys are locked
+        /// </returns>
+        Task<IReadOnlySet<Guid>> GetLockedContentKeysAsync(IReadOnlySet<Guid> keys);
     }
 }

--- a/ContentLock/Services/ContentLockService.cs
+++ b/ContentLock/Services/ContentLockService.cs
@@ -195,5 +195,34 @@ namespace ContentLock.Services
                 throw new ContentLockException($"Error unlocking content {contentKey} for user {userKey}", ex);
             }
         }
+
+        public async Task<IReadOnlySet<Guid>> GetLockedContentKeysAsync(IReadOnlySet<Guid> keys)
+        {
+            try
+            {
+                if (keys == null || keys.Count == 0)
+                {
+                    return new HashSet<Guid>();
+                }
+
+                using (var scope = _scopeProvider.CreateScope(autoComplete: true))
+                {
+                    // Fetch all locks in a single query
+                    var allLocks = await scope.Database.FetchAsync<ContentLocks>();
+
+                    var lockedKeys = new HashSet<Guid>(
+                        allLocks
+                            .Where(x => x.ContentKey != Guid.Empty && keys.Contains(x.ContentKey))
+                            .Select(x => x.ContentKey));
+
+                    return lockedKeys;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting locked keys for provided content keys");
+                throw new ContentLockException("Error getting locked keys for provided content keys", ex);
+            }
+        }
     }
 }

--- a/ContentLock/Services/ContentLockService.cs
+++ b/ContentLock/Services/ContentLockService.cs
@@ -212,7 +212,7 @@ namespace ContentLock.Services
 
                     var lockedKeys = new HashSet<Guid>(
                         allLocks
-                            .Where(x => x.ContentKey != Guid.Empty && keys.Contains(x.ContentKey))
+                            .Where(x => keys.Contains(x.ContentKey))
                             .Select(x => x.ContentKey));
 
                     return lockedKeys;


### PR DESCRIPTION
## Overview
Implements Umbraco Flag Provider to show an icon and message on the nodes in the tree for any items that are locked
Resolves #69 

This also works with the SignalR reactivity so that all connected users get the new Sign/Icon from the FlagProvider in realtime when a node is locked or unlocked.

### Tech Notes
Adds Umbraco Flag Provider - to show an icon/sign in the tree for locked content nodes and uses the `UmbRequestReloadStructureForEntityEvent` event to get the tree to reload & re-request from the server the item and thus get the latest state of the FlagProvider for it.

### Umbraco Docs
https://docs.umbraco.com/umbraco-cms/17.latest/extending/flag-providers
https://docs.umbraco.com/umbraco-cms/17.latest/customizing/back-office-signs

## Screenshot
<img width="959" height="1044" alt="image" src="https://github.com/user-attachments/assets/f00cec0b-6c0f-45ae-a358-77059f13f643" />

