### PR TITLE
Feature: Autolock / unlocking nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**Umbraco Community ContentLock** is an open-source NuGet package for **Umbraco CMS 17** (Bellissima backoffice) that prevents content editing conflicts. Editors can lock a content node while editing; locked nodes become read-only for everyone else, and publish/save/unpublish actions are hidden for other users. Real-time lock state is pushed to all connected backoffice users via **SignalR**.
+**Umbraco Community ContentLock** is an open-source NuGet package for **Umbraco CMS 17** (Bellissima backoffice) that prevents content editing conflicts. Editors can lock a content node while editing; locked nodes become read-only for everyone else, and publish/save/unpublish actions are hidden for other users. Real-time lock state is pushed to all connected backoffice users via **SignalR**. An optional **Auto Lock** mode (opt-in) locks a node automatically when an editor first changes it, and releases it on save, leaving the node, disconnect, or after an inactivity timeout.
 
 - NuGet package ID: `Umbraco.Community.ContentLock`
 - Current version: `17.0.0`
@@ -18,6 +18,7 @@
 │   ├── Client/                   # TypeScript frontend (Vite, Lit web components)
 │   │   ├── src/                  # Frontend source
 │   │   │   ├── api/              # Auto-generated OpenAPI TypeScript client (hey-api)
+│   │   │   ├── autoLock/         # Auto Lock workspace context (lock-on-edit + heartbeat)
 │   │   │   ├── bundle.manifests.ts  # Root manifest bundle
 │   │   │   ├── conditions/       # Umbraco extension conditions
 │   │   │   ├── dashboards/       # Content Lock dashboard (overview of all locks)
@@ -58,12 +59,13 @@
 
 ### Backend (C#)
 
-- **`ContentLockService`** — Core service for lock/unlock/overview operations. Uses Umbraco's `IScopeProvider` / `NPoco` ORM to read/write the `ContentLocks` database table. Logs audit entries via `IAuditService`.
-- **`ContentLockApiController`** — Versioned Umbraco backoffice API (`/umbraco/api/contentlock/v1/`). Endpoints: `GET Lock/{key}`, `GET Unlock/{key}`, `POST BulkUnlock`. After each operation, broadcasts the change via SignalR to all connected clients.
+- **`ContentLockService`** — Core service for lock/unlock/overview operations. Uses Umbraco's `IScopeProvider` / `NPoco` ORM to read/write the `ContentLocks` database table. Logs audit entries via `IAuditService`. `LockContentAsync` takes an `isAutoLock` flag, and `ReleaseAutoLockAsync` removes a lock only when it is an auto-lock held by that user (so manual locks are never auto-removed).
+- **`ContentLockApiController`** — Versioned Umbraco backoffice API (`/umbraco/api/contentlock/v1/`). Endpoints: `GET Lock/{key}`, `GET Unlock/{key}`, `POST BulkUnlock`. After each operation, broadcasts the change via SignalR to all connected clients. The unlock endpoints also broadcast `ReceiveLockUnlockedByUser` so an auto-lock holder can be told who removed it.
 - **`ContentLockHub`** — SignalR hub (route: `/umbraco/ContentLockHub`). Tracks connected users with a `ConcurrentDictionary<Guid, ConcurrentHashSet<string>>` (one user can have multiple tabs/connections). On connect, sends the caller the current lock list, connected user list, and current options. Uses `IOptionsMonitor` to reactively push option changes to all clients.
+- **`ContentLockHub.AutoLock.cs`** (partial) — Auto Lock hub methods `AcquireAutoLock` / `ReleaseAutoLock` / `AutoLockHeartbeat`. Tracks auto-locks per connection so `OnDisconnectedAsync` releases them, and runs a per-lock in-memory inactivity timer (mirrors the WebRTC ring-timeout pattern) that releases the lock server-side; the heartbeat resets it.
 - **`IsLockedFlagProvider`** — Implements `IFlagProvider` to attach a `Umbraco.ContentLock.Locked` flag to `DocumentTreeItemResponseModel`, `DocumentCollectionResponseModel`, and `DocumentItemResponseModel`. Used by the frontend to show visual lock indicators.
 - **Notification Handlers** — `ContentDeletingNotificationHandler` and `ContentMovingToRecycleBinHandler` auto-unlock items when they are deleted or moved to the recycle bin (cancels the operation if a different user tries to delete a locked item).
-- **`ContentLockMigrationPlan`** — `PackageMigrationPlan` with two steps: create the DB table, add the `ContentLock.Unlocker` permission to the Administrators user group.
+- **`ContentLockMigrationPlan`** — `PackageMigrationPlan`: create the DB table, add the `ContentLock.Unlocker` permission to the Administrators user group, and add the `IsAutoLock` column to `ContentLocks` (distinguishes auto-locks from manual ones).
 - **`ContentLockOptions`** — Bound to the `ContentLock` appsettings section. Supports reactive updates via `IOptionsMonitor`.
 
 ### Frontend (TypeScript / Lit / Umbraco Bellissima)
@@ -72,6 +74,7 @@ All frontend extensions are registered as Umbraco extension manifests (loaded fr
 
 - **Entry point** — On init, appends a `CanShowCommonActions` condition to core Umbraco actions (SaveAndPublish, Save, Publish, Unpublish, RecycleBin.Trash, Rollback, MoveTo, Delete, DuplicateTo) so they are hidden when a node is locked by someone else.
 - **`ContentLockSignalrContext`** — Global Umbraco context that manages the SignalR connection. Maintains observable state for `contentLocks`, `connectedUserKeys`, and `contentLockOptions`. All UI components observe from this context.
+- **Auto Lock workspace context** (`autoLock/`) — Per-document workspace context (opt-in via `AutoLock.Enable`). Observes the document workspace's `data` + `getHasUnpersistedChanges()` to acquire on first edit, sends a throttled heartbeat while editing, releases on save/leave, and shows a notification (naming the user) when another user removes the lock.
 - **Conditions** — `ShowLock`, `ShowUnlock`, `ShowLockedStatus`, `ShowPreview`, `EnableOnlineUsers`, `CanShowCommonActions`
 - **Dashboard** — Shows a table of all locked nodes with bulk unlock capability.
 - **Header App** — Shows the number of other online backoffice users; clicking opens a modal listing them. Only shown when `OnlineUsers.Enable` is true.
@@ -153,17 +156,25 @@ SignalR events (server → client):
 | `AddLockToClients` | When a node is locked | `ContentLockOverviewItem` |
 | `RemoveLockToClients` | When a single node is unlocked | `Guid` (content key) |
 | `RemoveLocksToClients` | Bulk unlock | `Guid[]` |
+| `ReceiveLockUnlockedByUser` | A user explicitly unlocks a node (sent before the removal) | `Guid` key, `string` name, `Guid` userKey |
 | `RemoveAllLocksToClients` | E2E test cleanup only | (none) |
 | `UserConnected` | New user connects | `Guid` (user key) |
 | `UserDisconnected` | User disconnects (all tabs) | `Guid` (user key) |
 | `ReceiveListOfConnectedUsers` | On client connect | `Guid[]` |
 | `ReceiveLatestOptions` | On connect or options change | `ContentLockOptions` |
 
+Auto Lock also uses three client → server hub methods: `AcquireAutoLock`, `ReleaseAutoLock`, `AutoLockHeartbeat`.
+
 ## Configuration (appsettings.json)
 
 ```json
 "ContentLock": {
   "SignalRClientLogLevel": "Info",
+  "AutoLock": {
+    "Enable": false,
+    "InactivityTimeoutSeconds": 300,
+    "HeartbeatSeconds": 60
+  },
   "OnlineUsers": {
     "Enable": true,
     "Sounds": {
@@ -175,7 +186,7 @@ SignalR events (server → client):
 }
 ```
 
-`OnlineUsers.Enable` and `OnlineUsers.Sounds.*` are **reactively applied** without a restart (via `IOptionsMonitor` → SignalR push). `SignalRClientLogLevel` requires a page reload since the SignalR JS client is already initialized.
+`OnlineUsers.Enable`, `OnlineUsers.Sounds.*`, and all `AutoLock.*` options are **reactively applied** without a restart (via `IOptionsMonitor` → SignalR push). `SignalRClientLogLevel` requires a page reload since the SignalR JS client is already initialized.
 
 ## Permissions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@
 - **`ContentLockHub`** — SignalR hub (route: `/umbraco/ContentLockHub`). Tracks connected users with a `ConcurrentDictionary<Guid, ConcurrentHashSet<string>>` (one user can have multiple tabs/connections). On connect, sends the caller the current lock list, connected user list, and current options. Uses `IOptionsMonitor` to reactively push option changes to all clients.
 - **`ContentLockHub.AutoLock.cs`** (partial) — Auto Lock hub methods `AcquireAutoLock` / `ReleaseAutoLock` / `AutoLockHeartbeat`. Tracks auto-locks per connection so `OnDisconnectedAsync` releases them, and runs a per-lock in-memory inactivity timer (mirrors the WebRTC ring-timeout pattern) that releases the lock server-side; the heartbeat resets it.
 - **`IsLockedFlagProvider`** — Implements `IFlagProvider` to attach a `Umbraco.ContentLock.Locked` flag to `DocumentTreeItemResponseModel`, `DocumentCollectionResponseModel`, and `DocumentItemResponseModel`. Used by the frontend to show visual lock indicators.
-- **Notification Handlers** — `ContentDeletingNotificationHandler` and `ContentMovingToRecycleBinHandler` auto-unlock items when they are deleted or moved to the recycle bin (cancels the operation if a different user tries to delete a locked item).
+- **Notification Handlers** — `ContentDeletingNotificationHandler` and `ContentMovingToRecycleBinHandler` auto-unlock items when they are deleted or moved to the recycle bin (cancels the operation if a different user tries to delete a locked item). `ContentSavedNotificationHandler` broadcasts `ReceiveSuggestReload` when a locked node is saved, so other users viewing it are prompted to reload.
 - **`ContentLockMigrationPlan`** — `PackageMigrationPlan`: create the DB table, add the `ContentLock.Unlocker` permission to the Administrators user group, and add the `IsAutoLock` column to `ContentLocks` (distinguishes auto-locks from manual ones).
 - **`ContentLockOptions`** — Bound to the `ContentLock` appsettings section. Supports reactive updates via `IOptionsMonitor`.
 
@@ -157,6 +157,7 @@ SignalR events (server → client):
 | `RemoveLockToClients` | When a single node is unlocked | `Guid` (content key) |
 | `RemoveLocksToClients` | Bulk unlock | `Guid[]` |
 | `ReceiveLockUnlockedByUser` | A user explicitly unlocks a node (sent before the removal) | `Guid` key, `string` name, `Guid` userKey |
+| `ReceiveSuggestReload` | A locked node is saved (content changed) — prompts other viewers to reload | `Guid` key, `Guid` changedByKey |
 | `RemoveAllLocksToClients` | E2E test cleanup only | (none) |
 | `UserConnected` | New user connects | `Guid` (user key) |
 | `UserDisconnected` | User disconnects (all tabs) | `Guid` (user key) |

--- a/ContentLock.Website/appsettings.json
+++ b/ContentLock.Website/appsettings.json
@@ -33,5 +33,10 @@
         "HMACSecretKey": "Uyc5P84OsFOin3J3bTp00\u002B4PnG/0dh1NrcQLpAdpYQ0vDH1pvvvgwGUGjyfhdH0Tl8xt8J/UFey\u002BZpImTV7cJA=="
       }
     }
+  },
+  "ContentLock": {
+    "AutoLock": {
+      "Enable": true
+    }
   }
 }

--- a/ContentLock/Client/mockServiceWorker.js
+++ b/ContentLock/Client/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.14'
+const PACKAGE_VERSION = '2.14.6'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/ContentLock/Client/package-lock.json
+++ b/ContentLock/Client/package-lock.json
@@ -54,29 +54,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -606,6 +583,7 @@
       "integrity": "sha512-LSBHP2/wTF1BnaccHGX1t+0Ss+2VJQxotrLz/0+LK2z8ocuyVZXOYhfBSd7FP8sK78MDJVDBYrPCsBUvNSlH1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hey-api/codegen-core": "^0.2.0",
         "@hey-api/json-schema-ref-parser": "1.2.0",
@@ -1044,8 +1022,7 @@
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
@@ -1140,9 +1117,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,9 +1134,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1180,9 +1151,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1200,9 +1168,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1220,9 +1185,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1240,9 +1202,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1889,7 +1848,6 @@
       "integrity": "sha512-nPzraIx/f1cOUNqG1LSC0OTnEu3mudcN3jQVuyGh3dvdOnik7FUciJEVfHKnloAyeoijidEeiLpiGHInp2uREg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tiptap/core": "^3.6.2",
         "@tiptap/extension-blockquote": "^3.6.2",
@@ -1942,7 +1900,6 @@
       "integrity": "sha512-xIeRVTnnC78VDgm3YxosgM1ODVKBdmyWuz4Dhhyc1UCPFptzNIPZuzNbOxyThFseqKh1LVDM+EmjshACE/3jVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1957,7 +1914,6 @@
       "integrity": "sha512-NWjOIIZdxUSkWLQrEY4Tg60MzS6RGt/1aLnwTyFFzFFShzOmd/xzxp0fRS+p79ZKNcQa9OKgnrlS4xuRq8WOdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1972,7 +1928,6 @@
       "integrity": "sha512-c6ycK/8TZEl8sw4Wkr4APpjeNaNhh4EJPBZ2bt4oHqkl+v5NCddo9xdP1sgsopNySPNQaHQSO5GYmU2QHbSBpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1987,7 +1942,6 @@
       "integrity": "sha512-POK3CCy29LoRI6JVvFRVAmH2G90a7pKJT8sbqOaX1WKmLLDt7drUxGgBNnz/cBXJQHPnXZgRq/P8ZQPISklT7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2002,7 +1956,6 @@
       "integrity": "sha512-Z6EH/DhSVQtOKL+vS9J2dbvJ81T3xJ2Htgn4BOxpuCGUCInu5Aymf/53tco3aQse/UHB3Gvr+/4AOwxphXYhgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2018,7 +1971,6 @@
       "integrity": "sha512-RlezqyAf0voUblrMLArh+AZJ9t+rE6buFa+U1V37Ey+I1z+Y8pPqlhtYJoTUz0GtSZWMReirSvoQpQJHM9x3Yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2033,7 +1985,6 @@
       "integrity": "sha512-VnI+lRpXi9Qa/RFeZYqGd5taApM8SD6qYBnL1FqwRx7eLpWH3UyH911d9/sFqYxouDy06XRDHPoqlyMw5afdwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2048,7 +1999,6 @@
       "integrity": "sha512-1VDNX+4ZCKxuoj6nRTZDwHjPYhuSdELYYCSfxscojlwexPxCLcgqOt71xdgnQXW5Hv6ACT4OrGGYcGTupudOHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2063,7 +2013,6 @@
       "integrity": "sha512-EIdTsD2pV4FSef/6nrKlXV8H5861PElnIjuoHkwk1alowAVL/HSvJqPxZwH6k2qLcsabkr0cSdaDixw9gJGAdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2078,7 +2027,6 @@
       "integrity": "sha512-Pp0LYTEyimDfiXzy+8Ls2LDuhhmyM7jXr8go3myTHSLMTpt0ch7P5FVSnDxMFtQ5eRiAwXHET63/JOaiIwMa/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2093,7 +2041,6 @@
       "integrity": "sha512-V9uWb341QUBDDbR3aoSs3Sx0PQQaKwZ/ESVEE03El9rkIrf8g5K82x8/M0nvSOvGobt6oRyI/rgbj196YQuXiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2109,7 +2056,6 @@
       "integrity": "sha512-1CQgHNm51xDyZI188f5xKLcUIjRS+2cyZgS9XwKwIU/3QOsiKsNC+cBc4VmN3aR0A01NjK0ch0MjeKkPPWUt5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2124,7 +2070,6 @@
       "integrity": "sha512-AIgrtveTQ5QyRpcic2MVSuv9aOaN0n+swdZPvi8XREZX/uf1SU4dYU7p0dNChhcn53GGPDNVRTQXX4YdEAZFQQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "linkifyjs": "^4.3.2"
       },
@@ -2159,7 +2104,6 @@
       "integrity": "sha512-beCOcDfOzCY9/7fAHY/O/RFcqxLPJWGBV/6YMMUkyW34rrb1NmSZp2qegTh+1820DHs7sokn/OeCIo8Fqs8lQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2174,7 +2118,6 @@
       "integrity": "sha512-QzDX+BY3z60sz3GfMK7oQV/CnAL0elRI+VdGyObuNS/RCpD6DKwa5Gb+vB9Qj3sUccViJOhBr8OpmLDtAoco8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2189,7 +2132,6 @@
       "integrity": "sha512-+rcJM0iqBVHBRlbupU8KmoTc3AD8maWJyQl05LrVQcAwmRDx3xtIagRnN1hwxSYavIFRwLATgYHSWd08nnL38g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2204,7 +2146,6 @@
       "integrity": "sha512-53+nCxNaKcmeqQ+aWrSauEWywuWPp8qkUTOO2rHlpmM+rk/1bv3IZePKQ2JtHZzYCeRd3xOC33kl60HE7EwakQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2219,7 +2160,6 @@
       "integrity": "sha512-pZMdQhChv59jsahvmjiJjSTPM05J6EHAX/GPdA9w8xSKy73899MhIhWJ7yt2CJEPjwn3ixnomIPhMjxBkizv+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2234,7 +2174,6 @@
       "integrity": "sha512-b7Rjil/uqiabWnRHyd1P84rWD2XRyZZSrmIAO9mDMD/jB2bE+f7rDJcHG76GF03UicDhEEEf2/8mz0dMLa6mUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2249,7 +2188,6 @@
       "integrity": "sha512-yBL81xdbjT5Y7acoBqWpnH/SoH3bpgqaLvJBG3NNk+mdLB5HjBWTlPLKjvjQV0HRN5bZ+RJWeiRnQk1ahcfmQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2558,8 +2496,7 @@
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -2567,7 +2504,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -2578,8 +2514,7 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -2846,7 +2781,6 @@
       "integrity": "sha512-WM08j2cGcJcbXWS6Pb9FdhaKDz3+EUSuoxrsZoGkJBJMriZLv4gq9EcE5RIstUbT8JmDPQ7uT3SDT2gZWl07MQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button-group": "1.16.0"
@@ -2858,7 +2792,6 @@
       "integrity": "sha512-1u6+hOLy5NrFh5/Z4Kp88y3Mhq+FYCZRwPb+5lSutm+aMy27dehRKkZqlbptWn/qocUCibDxQpruvu/UMtVQtg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2869,7 +2802,6 @@
       "integrity": "sha512-509UZzUSD/JhJEVLEpT5ltccHpEw8RxoZbG+hJeg23Oh3jNuRrKvuiyOut5c6JfjMdawHw6vPivVwjqCmbZG5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-avatar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0"
@@ -2881,7 +2813,6 @@
       "integrity": "sha512-sHo71JOxxk0EufgYfCl9miuYgM1LDSnmtHedvDGs776htMFkLo3W/cFWgIXabAHZeSj4R5UWMGDNsugwv03R+w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2892,7 +2823,6 @@
       "integrity": "sha512-8i9bdcSrdR/4lWm0xetr3R3w3Rod3YVbIddHqbb3iVrr0TmPDTVA48tnOsJyQFAvTrh2LZjiETvEve7pBy4WQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "lit": ">=2.8.0"
       }
@@ -2903,7 +2833,6 @@
       "integrity": "sha512-IRU2z3GV+WzyjUvIMeErYeOE/0GyOpItsXxfmxsEENT/7qq4UMk28fIxY9IdDfI285WP0N3kezWkPBPlCKBcNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2914,7 +2843,6 @@
       "integrity": "sha512-/Wgnv2jr6wKG436WNjBdGq6x+aExiZhZgLPnzrTcaevy85MM5pJZWgY1+aI+pJclgU6WtRMii2+C8MZL2Qmh0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -2926,7 +2854,6 @@
       "integrity": "sha512-PuLcxG+3ZeSXKH3M0Kkh3eVYOEJPwLfg+6+b4UXxV/O9p0tUFbNPc8ciggL/1ZBXYXjsQnFTaOQWV4zGpnCnFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2937,7 +2864,6 @@
       "integrity": "sha512-0nTAx/GVOdGvlekkIxZp1nJs2E1DRzbdUnARl6RN5Oc40HowW9oO5oJvDIpoZcsWqkqWzFTQqVgE1z1PafKHZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0"
@@ -2949,7 +2875,6 @@
       "integrity": "sha512-CXjJzLbedqHtlza2zspSWNZCw5XhHV5QkPFzRI5Zd8FwFZop1/UgM2GQeSrMaWdfpznbWvfUqnvSYt9wYEubVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0"
@@ -2961,7 +2886,6 @@
       "integrity": "sha512-ygici33P70SJqa2SSjdSVd8paSKqHwewKJMcyIF/IehDepnDP0ngSHWA23B/sEzJNJgq0Zngo9g3jlhZz6H6GA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2972,7 +2896,6 @@
       "integrity": "sha512-To9K/mYXLm4SGih3uA8/jbZd/ewWKVvYH6b26F5fvEDVT+X9fjJchKT7J/u0a4C7wghvVNT+os7H0rxS3yTXiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2983,7 +2906,6 @@
       "integrity": "sha512-o/8vDLT03WnQsJKyD8r7PzxvhD3loRI7pL3tZU1BeSDcFAOZPPWIudQ/OwYeJnMI1iHkd2eTu0h22B/sXOfIIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-checkbox": "1.16.0"
@@ -2995,7 +2917,6 @@
       "integrity": "sha512-Xpq/kB/ofSn067teaOyS4hEsEt/WUlrJ0opTFgkwHxsWg9rvMzUtg2nc2JGMoIqJ64/40Axcx0jmmchIDUcbsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0"
@@ -3007,7 +2928,6 @@
       "integrity": "sha512-VPRDFrZSPLDGE3kAarW78dZHIFBhwXakyj7PM278tcXGdfSM7M9HsLXME6DhlleOYfSV07wHXm0UXKieqO7vgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0",
@@ -3020,7 +2940,6 @@
       "integrity": "sha512-IHFCnXr4Bdpj/aUn+jpmlYx9L0FzeWTwt+cb29b4oP0cjIiVaJIrkOCSIl3SF8ncrKfMlTjlgBe0t0sP4mjeug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0",
@@ -3034,7 +2953,6 @@
       "integrity": "sha512-Ne64+ssQrpP9zJvlJhH1Y5xlEDMW1lG17Orj6XH99iDtGdrnug9FjRE4vpNfAVRIb9P1pf7xNJtq2XqCJHvqOQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-avatar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0",
@@ -3047,7 +2965,6 @@
       "integrity": "sha512-B3xNrwkQBwye9ydlrvnYfbJyiLqwQEbpldfaJnjLvlW9xVhOFps2NfeRyXcdsvruaIwjml7aB18GVYDCd/PSlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3058,7 +2975,6 @@
       "integrity": "sha512-4z8XrZ0InVArdHKO7L7uwAMwUwHyQKqSYShE74VHHWOibySciJ/zPx3hFO3eQ7EBL3Kj+4raun5Ah5jHUlDZwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-boolean-input": "1.16.0",
@@ -3071,7 +2987,6 @@
       "integrity": "sha512-wiK9WNZWZ5yFd3ouTZOcoUSm+2iNZIFlGTaTScnG/DiLCBs6DUvdbSbVHueY1cGWbOx/R8N01kZBls1fk8kaHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "colord": "^2.9.3"
@@ -3083,7 +2998,6 @@
       "integrity": "sha512-IilZw7Qn+2QF80OXktnoY1RI45ggl8o+QyF5a6zjd2gl5BfwAVx/uFCnpDfjH6LKtRw9WvuPKHQyM0/mfi5I4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-popover-container": "1.16.0",
@@ -3096,7 +3010,6 @@
       "integrity": "sha512-GDlAv+75efrOq9K/mZSKLwmc/ZG82hCaRMpWI4guKKvJhcukIcg7Bt/jQrDrtEGKCYvMJpNzbqZ41b+x23EQEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3107,7 +3020,6 @@
       "integrity": "sha512-I+0iEkIGXzoDfLUj0duUJsdf71FC1EBqNzAH/X5noiWc+RZiAAw5EvXm7rZO69oDNOQMwt/yMCBLJQp2kYOQTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
@@ -3120,7 +3032,6 @@
       "integrity": "sha512-i58T2PRYzViBTo7OtJAGi5inVF8jxVYBmLL7nb3dpNjUFTZZufRKTr3AsVS7+pCGEogFmyNbcNztmmEMdU4ekA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-color-swatch": "1.16.0"
@@ -3132,7 +3043,6 @@
       "integrity": "sha512-zjeNG+7r5J4UgdeWh8Osktkjk/Uret5tu8mUtpp0Z6LIbxISUKEt9QlbjPPorxB3V0ENKUJ2c5KZZtpj7mLihQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -3149,7 +3059,6 @@
       "integrity": "sha512-gNFheYUtzMvQudvzoRhDgJk9zziFTxSyu92aYzyoyhh7M098gJfqU+fo7Teqqiuyb0NEiZPThcNrUT9MD2LD3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3171,7 +3080,6 @@
       "integrity": "sha512-dq+daSQKAIdsP+2QhM6HmU9Nr5VVzbxwQEYLVvAcmYcw4K98TVpP6AyHu5dPDP9vl4EBBXUrrZuXFjU+Mh8/xQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -3183,7 +3091,6 @@
       "integrity": "sha512-iRpmlzp1PAUpF6Ol2EWubdABIgpJE6QmBzaQONm3Mmwe1wLxMGp5+o33wHU9WSTh8kDrH/U5mWtua6Xtyf5JFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3194,7 +3101,6 @@
       "integrity": "sha512-B3Zy6jlyK68ntaC4idv7fzd9NVyc4VVjn68DgkvnHR76Mp8zmOgT0g7K7/WM33IPw/n/ZfBhM1KEb+ry3i9/bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-symbol-file-dropzone": "1.16.0"
@@ -3206,7 +3112,6 @@
       "integrity": "sha512-A+jych/xEUOssZjqWtW04nD1GcVOHnonTlPdrDaFh9PhwQAL0PREBbHZnkLJBS4z+HKWhsXOUeQ9ju0YAtbRuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-symbol-file": "1.16.0",
@@ -3220,7 +3125,6 @@
       "integrity": "sha512-mZVeqQtKirPHCES6TcTywELJi3raBgSKRt2XKCmHMDzclK9P11qPuOve335Jd8WPISsqbbcw4mIAGQpww7TxIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3231,7 +3135,6 @@
       "integrity": "sha512-g1xYut9TQzAK1w0fijWyV2PlXJnaMw3MYgytvsEu3XD93hPut4XvkifM8Ja6YxpkRcKQpRRLa4WHroQ6OQY6LQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-form-validation-message": "1.16.0"
@@ -3243,7 +3146,6 @@
       "integrity": "sha512-55+WAkF02Im+bG1Xl1AABA7KIGXr5CZTgHbr3MsVVHJMtHv+gQZ04h+0TkvDzKZDSg8ucCXJKyD44Y4gOyS2oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3254,7 +3156,6 @@
       "integrity": "sha512-x7HX9OnKOTgjbFbSSZ9Pk0+Lf6yo8ggLe6XTnPClu3ByN2fl9/QqshI5lx4oz5Adr/ItSj3zqnNB2JbyM56TLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3265,7 +3166,6 @@
       "integrity": "sha512-o4l2bEYKdBcxAlSwEPO+cfnNvkGuGcZRyca026xvIz+nufbc/BBzskzS1UWIIjkFPu64rHEfxP/3KbSld64HYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon": "1.16.0"
@@ -3277,7 +3177,6 @@
       "integrity": "sha512-HI4cnYhWpPtWFFgfEltjV6PPhOd3NQ58BhqfbCpRbwmHZUZ0OBzGRl4QgsPNKuhQqmcXene+Twfy8eoRk1/5nQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry": "1.16.0"
@@ -3289,7 +3188,6 @@
       "integrity": "sha512-2Mp15ObjyAuRD3bOTs/zuUHqaaMiuDhmGsjeK8ViOrlSMnz/bVUme5scN1OMkNIryVHkENshC4NK7x6++X0/qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3300,7 +3198,6 @@
       "integrity": "sha512-AxepSUJe0LmY4QmBA9UlzhZBBrVF+z88fFUWIH15PICFX0jfsPNIeiwQKlv7cN5pEInUh6qCRN64z8icf8fcdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-action-bar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0",
@@ -3316,7 +3213,6 @@
       "integrity": "sha512-FTLj/2s+VImEtKe1GPSkAC2pmTabz5cGzvaFB/7xrJj/1evVxXGu8qQyyL96WoDe+RAmBNYfrnGx7OUSVhEyRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -3330,7 +3226,6 @@
       "integrity": "sha512-0gg8nAVHsMYlQscG76PN4L8ha3CpW15crlzgj4TMaW24OIgZ0khV18ZImJ5n9wv/zrq8LsrwJTyZ5/a/soaKyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
@@ -3343,7 +3238,6 @@
       "integrity": "sha512-z9wlhONxtwkUCkPEKqt/vSH1qOTwHCIM2Cj/DQ21+bfWcywUR7cAp0vRveapymDn4eHSuRra5lrG7xgLYsYuVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3354,7 +3248,6 @@
       "integrity": "sha512-1vQAKUR+frDEth8AMLS5KKpVK2LHD61lWUG95yMypF5C2+YBmzXb70QEakOubTMsmLnYcU3hfORfA5Wp9cYPnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3365,7 +3258,6 @@
       "integrity": "sha512-wcFUljPcrAR6YYuj5XLmtMpZBvzTBcakr9p+vISOoC3ta8UlE+OOLiQn+XYzTuV/ZbM77EHh5EEyiO5L45fQew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3376,7 +3268,6 @@
       "integrity": "sha512-xh6RCS60WPWPzf0dAA+lTTt0rF8hksQsYBLwITBsR/5k3qswhT9Ctu/2LvqUXoLPyEFTecA4fyqZK+NzhjZrdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3387,7 +3278,6 @@
       "integrity": "sha512-jawUHoiUwwZkp5YOLFlF00WvZ5yPowfbi22TufSyfls5hMajJM/p21IrCTStrc4ZimqyheaaYe/AqdGLDimfSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3398,7 +3288,6 @@
       "integrity": "sha512-tyyuehJSj1BU/EEsQ1LHN8eg+gcAKCzqGMwwpepEtKZDd7p1/Ioq1KEn2e20UOihXab5rFv5UNEWSeyEYRqL4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-loader-bar": "1.16.0",
@@ -3411,7 +3300,6 @@
       "integrity": "sha512-hqlXHjlGxEWEeX5c7W0xNlH25xDbb8vdgBIfYGUkBfrYrgO3j+AJ/B7OvmgWJogFTOHRRaPUvKDi8DkDnDH4zw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3422,7 +3310,6 @@
       "integrity": "sha512-bZQl5BwiYHSQqc0bjajQbu8ZX+z4qe56t6PiT6s+VUj6huXOOrT72hpY2u+ZE22sAWPaIu42Kg9ulxNV2pulRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -3435,7 +3322,6 @@
       "integrity": "sha512-ZtHPdupRjxwuSHmY5EiiGtZMBi5UsAyHOucn5SxMgdyHT7bRxrV1ebCblDu4eikXg/xx1nTDSFmmW4rXLftULg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3446,7 +3332,6 @@
       "integrity": "sha512-3N8M4hPQFcthVfqfhdCMX9B4q+0sG2zizoQf2SvDoLp3GAqND2zw2cwYClMy8HJh3XH9JINljz3PliyKMXVaXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3457,7 +3342,6 @@
       "integrity": "sha512-GE/ZW5Rq82LgVbArppIG8Zkd6QFmCTGEV4Iq5V4KPOl5iSVu2yuYJCDD77aR1LgclSjk1YiJ1/oge94RXqAtOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3468,7 +3352,6 @@
       "integrity": "sha512-r3JmVGeGzCzUPEKdOzxunsoRO2q7zGoI5eUtrSXdLSFiR2klW+hti/fjvqvruqzRZRjB0oumbJfMU4IxHcZblw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3479,7 +3362,6 @@
       "integrity": "sha512-9qx3Qj8kmIyHRbcVNexWTs4eGjsxs9FkjP7czpC1P0CPJFIt8LzeB6gBwSS/nJGuIo06RQ42qOc8FOza2tN+jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3490,7 +3372,6 @@
       "integrity": "sha512-+ptIzEx8a3Oy4XL6TFibR5Q5lWDpjCSPCN2DgIitBj9C0R8zWbBo8sxj2iLGP4RsBiHeTUbDiJlSY1seo2E+Ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3501,7 +3382,6 @@
       "integrity": "sha512-MRxTX8CDvquBkkEGfpPsX5ttnsPGJ+Kb1KfR+arueXazQ9XfqyoFCAWWXfOxGL7A5txGTMnKEfj59dyLeCec5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3512,7 +3392,6 @@
       "integrity": "sha512-4IO02sBoJLlErxXPeFBXTtOZzQeFbCf0flpHCjMZ+vWKZ6GarlUMSvbXjuzh5SBEveVxWYhjd7Z7lP+g2pOHGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon": "1.16.0",
@@ -3525,7 +3404,6 @@
       "integrity": "sha512-0yRbSOoKl5gSAnRIEXTdFYlrt4NSvuLx1+TuQyeE/CV8lfObGqM1+y+ueX0AgPuNTXAf7j5rPIRLsVJHfCs2MA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -3537,7 +3415,6 @@
       "integrity": "sha512-ORBBH6GRq5VFTNZd++f7dXCLJdgEGhtd1rcdbxjqtYnJrKeJ0dBNhJkF3kLoSQ1MiOG1SHOckGUZr5nLMUhc/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -3549,7 +3426,6 @@
       "integrity": "sha512-Z3m2toN+LcZOXVe/3q6d9kyPyWXR9l8CJSk1NkEn/ojMYrRzmo5AW92xWw/twHV8bRsEBDSeKxSKMVGnJVyUHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -3561,7 +3437,6 @@
       "integrity": "sha512-v9m/e5krM1IPV1gI/9dqVKgGYthyWXDlq9lCdiigpTfzv7xkCF+LPEmVksDZaKD498gGYtbYJReCXUxCwjxGTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -3573,7 +3448,6 @@
       "integrity": "sha512-6z/oa4qX+L746nEet0EDx88roSTcfjnzQj5fH2ebW4WJ6Arh/b+QmPOE3UEn2QiqjJLovkIhNcwf0m9PM7rSSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -3585,7 +3459,6 @@
       "integrity": "sha512-TdYTh+1pZfOFD9dKBtti1oDF1Pk5Bp3PyNKf1JLtcPm8uD/UPDxRkIYV7It04E6P7VWusdRabdlv/q9PRimA5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -3597,7 +3470,6 @@
       "integrity": "sha512-+ArdQO09sGB1t24rzi+rk3YsZZayZRr5aKny53qAKkklJg0IDCJ+Vme9DvuSk0HBEzCe0YF313lv5mYjxFwCzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3608,7 +3480,6 @@
       "integrity": "sha512-/tXty/HSqTAwnqsmLIsDc8LsE7XW0pZaCu+B/Ov3FjYQSb312AqXBwP7Z59gAbh2M0XvI3qxcA/sLcFndqN1oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3619,7 +3490,6 @@
       "integrity": "sha512-zWXe+SOzXbhO2tN+DnVXbefEWICZ+FHCR1EGldZdab3hQO53M4HOKqTBd1akE6iFli7FN4BOnELGjnMnupaqvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3630,7 +3500,6 @@
       "integrity": "sha512-w9i+deCNhZ3TzwgMx2glGbpyvXQHyP0kCmuazXi4cYGFtEXM48d1OScm/PrGs04ICNuqEIwY/IZ+PGfRSI27lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3641,7 +3510,6 @@
       "integrity": "sha512-8iyZCjVAFvKrz1m0RTPiZmbXYLyb0Gs2blgg/uPyBzpNvptnXgx29UVTzITu2xvqVvwvureFNcxqeYL5WsfCiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3652,7 +3520,6 @@
       "integrity": "sha512-d9VJQTEBKwTHrvgPAXLgG4m3quDbxg1EhJhE03cxZr/yrZ81I2TD3wd4Pt9uxL1kvpZ95mP2vDfbedUfm/0fww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3663,7 +3530,6 @@
       "integrity": "sha512-PMm3lTtIAwyE+6Erz2xiamKPuHhqazk2aWHgqC9fzD/0ROlWQMYEP3M99onp8/YCIprzfvXPuH6ofs6kq9bY7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3674,7 +3540,6 @@
       "integrity": "sha512-vATvt+AcfP9pZxh99DKaq/wrD60EN4nvdtZ/BpHH6MOhX32T8LEboh57XisHmGamUSGbm2jQhASJTt+7cvjI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3685,7 +3550,6 @@
       "integrity": "sha512-mAFnPdUzlddfdLMTkBetCTnShV3QTWMpjqaG5fCaauizWmReye/rCwDur51URL+VkWMIWp29JvfYIIm8Yk+ZGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3696,7 +3560,6 @@
       "integrity": "sha512-WBd/6SNLVP04WU0Em8Uc9/GXsKYpYdHzlEjh7w5oU1TfbDEiNq1lXkOlpuvL79wJtd/2fTKfqui02+i79KU7ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3707,7 +3570,6 @@
       "integrity": "sha512-hBhvUmkPc5WgFcjKDm6jtQq2USCO+ysveJRI1oJReiZkyj06IjU5mYddUL/sOG4L7Ud6OFqVbY002Uw+j9QpYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3718,7 +3580,6 @@
       "integrity": "sha512-cVq84cwbgOvjoTn+5L4eboXPGkYdcIkWm/oU8GxbR1OdUtgPtqnPwB51Ial6ylyIHqvYbCDmDMzrjjnrB/qfJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3729,7 +3590,6 @@
       "integrity": "sha512-FBToNg7zgB9paPQPbpnuC66KAMz3iR/F+tmLhjWnwGSit7ubFspPqgrReSjVS9zdd+zbi7wTJOcmKnHmoyP1bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -3743,7 +3603,6 @@
       "integrity": "sha512-u6pBhOEvXYvUNTxNO1Ftcnflii1CmeuvNAXxuIj8TMmTXGXWmap0W5cGmzlEbbLAMGLv56AJXdz3rKDrWNyTvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3754,7 +3613,6 @@
       "integrity": "sha512-xTO4i/m4Q7wEeaxmV1bxT5e1bnLRJ1CoG+awe2FKGq6xw2ZHgksSrm6j3Ddbm5WzV019hIeVl22bnVQ5gOwrww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -3765,7 +3623,6 @@
       "integrity": "sha512-ziOJ4uyQpIVCBym2RlZFJOuOb2feNr1sP0RxUjhXToREJdG2MH2bgYyy76K0OCZ7a+JKCsHdaBH4XquXIH93VA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -3780,7 +3637,6 @@
       "integrity": "sha512-8HwiYkOA8Rsxpp2ZGsDTq16odV7Ja7xAAp/0BcdosdQYn6L4KUbSimulGaP/Q1KATUCFT7QflQiv0gnwuPpngQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-toast-notification": "1.16.0"
@@ -3792,7 +3648,6 @@
       "integrity": "sha512-OTrTAGUPe8EQRuCWJD8GsCw8MfNJuXx50NLZLDDZKzw3TlDiWMxUD0c4l6zOMy4ih7n7D5sMekHqonW5x6lVuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -3804,7 +3659,6 @@
       "integrity": "sha512-opFdwN0LlH6l1xlzEv+e9tvLgySXRr4Ug5LBlzNRJKC/WhinUSq/okerIVyUJgk4oKdZV/y7T7u/07LiekCTAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-boolean-input": "1.16.0"
@@ -3816,7 +3670,6 @@
       "integrity": "sha512-fqcv9gZUey2FkE2IRWuDgpk+D5XCdC1gnmQ4bIlAs03cMhl2BWP7U04Zo1u78jcWCbjxfnp60rfE6h11ukd5sg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -5062,8 +4915,7 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
@@ -5207,8 +5059,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -5431,7 +5282,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -5544,7 +5396,6 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -7126,7 +6977,6 @@
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -7136,14 +6986,14 @@
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lit": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
       "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -7246,7 +7096,6 @@
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -7295,8 +7144,7 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -7421,7 +7269,6 @@
       "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.1.7",
         "marked": "14.0.0"
@@ -7432,8 +7279,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
       "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
       "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/monaco-editor/node_modules/marked": {
       "version": "14.0.0",
@@ -7441,7 +7287,6 @@
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7769,8 +7614,7 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/outvariant": {
       "version": "1.4.3",
@@ -8071,7 +7915,6 @@
       "integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
       }
@@ -8082,7 +7925,6 @@
       "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0"
       }
@@ -8093,7 +7935,6 @@
       "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -8106,7 +7947,6 @@
       "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -8119,7 +7959,6 @@
       "integrity": "sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -8133,7 +7972,6 @@
       "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
@@ -8147,7 +7985,6 @@
       "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
@@ -8159,7 +7996,6 @@
       "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
@@ -8171,7 +8007,6 @@
       "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
@@ -8184,7 +8019,6 @@
       "integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crelt": "^1.0.0",
         "prosemirror-commands": "^1.0.0",
@@ -8209,7 +8043,6 @@
       "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.25.0"
       }
@@ -8220,7 +8053,6 @@
       "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -8246,7 +8078,6 @@
       "integrity": "sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-model": "^1.25.0",
@@ -8261,7 +8092,6 @@
       "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remirror/core-constants": "3.0.0",
         "escape-string-regexp": "^4.0.0"
@@ -8278,7 +8108,6 @@
       "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.21.0"
       }
@@ -8371,7 +8200,6 @@
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8695,6 +8523,7 @@
       "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8739,8 +8568,7 @@
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -9381,6 +9209,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9431,8 +9260,7 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -9617,8 +9445,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/ContentLock/Client/package-lock.json
+++ b/ContentLock/Client/package-lock.json
@@ -30,13 +30,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -45,19 +45,44 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -73,9 +98,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -90,9 +115,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -107,9 +132,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -124,9 +149,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -141,9 +166,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -158,9 +183,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -175,9 +200,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -192,9 +217,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -209,9 +234,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -226,9 +251,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -243,9 +268,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -260,9 +285,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -277,9 +302,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -294,9 +319,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -311,9 +336,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -328,9 +353,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -345,9 +370,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -362,9 +387,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -379,9 +404,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -396,9 +421,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -413,9 +438,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -430,9 +455,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -447,9 +472,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -464,9 +489,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -481,9 +506,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -498,9 +523,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -578,9 +603,9 @@
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.85.0.tgz",
-      "integrity": "sha512-LSBHP2/wTF1BnaccHGX1t+0Ss+2VJQxotrLz/0+LK2z8ocuyVZXOYhfBSd7FP8sK78MDJVDBYrPCsBUvNSlH1g==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.85.2.tgz",
+      "integrity": "sha512-pNu+DOtjeXiGhMqSQ/mYadh6BuKR/QiucVunyA2P7w2uyxkfCJ9sHS20Y72KHXzB3nshKJ9r7JMirysoa50SJg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -599,7 +624,7 @@
         "openapi-ts": "bin/index.cjs"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=22.10.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -609,27 +634,27 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -641,23 +666,22 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
         "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -682,23 +706,23 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -745,18 +769,18 @@
       "license": "MIT"
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
-      "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
-      "integrity": "sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@mdn/browser-compat-data": {
@@ -799,10 +823,32 @@
         }
       }
     },
+    "node_modules/@microsoft/signalr/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/signalr/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@microsoft/signalr/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
-      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -817,15 +863,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -875,9 +928,9 @@
       }
     },
     "node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
       "dev": true,
       "license": "MIT"
     },
@@ -907,9 +960,9 @@
       "license": "MIT"
     },
     "node_modules/@open-wc/scoped-elements": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-3.0.6.tgz",
-      "integrity": "sha512-w1ayJaUUmBw8tALtqQ6cBueld+op+bufujzbrOdH0uCTXnSQkONYZzOH+9jyQ8auVgKLqcxZ8oU6SzfqQhQkPg==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-3.0.10.tgz",
+      "integrity": "sha512-esE95vxq6Y7w9/8H/oPvqN9QVR+ys3F9J2/ITyuTWnlSYaJueQmcS5CR5OybJMjjm9R5pmSoOe6Vau/O7J6d2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -956,9 +1009,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -966,14 +1019,14 @@
       }
     },
     "node_modules/@playwright/cli": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.1.tgz",
-      "integrity": "sha512-9k11ZfDwAfMVDDIuEVW1Wvs8SoDNXIY1dNQ+9C9/SS8ZmElkcxesu5eoL7vNa96ntibUGaq1TM2qQoqvdl/I9g==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.14.tgz",
+      "integrity": "sha512-DoKzrzEN/ivdxFy61Kbqzsz/U4+6F6Nk1Psu9hSYYYriqhzifW57VuNciuXjFS5Xuyhb8aXcy5hCgbDdqr3EIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "minimist": "^1.2.5",
-        "playwright": "1.59.0-alpha-1771104257000"
+        "playwright": "1.61.0-alpha-1781023400000",
+        "playwright-core": "1.61.0-alpha-1781023400000"
       },
       "bin": {
         "playwright-cli": "playwright-cli.js"
@@ -983,9 +1036,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
-      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1005,9 +1058,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1017,17 +1070,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@remirror/core-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1042,9 +1088,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1059,9 +1105,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1076,9 +1122,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1093,9 +1139,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1110,9 +1156,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1127,9 +1173,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1144,9 +1190,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1161,9 +1207,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1178,9 +1224,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1195,9 +1241,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1212,9 +1258,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1229,9 +1275,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1247,44 +1293,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1299,9 +1311,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1316,9 +1328,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1348,9 +1360,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1370,10 +1382,23 @@
         }
       }
     },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
       "cpu": [
         "arm"
       ],
@@ -1385,9 +1410,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
       "cpu": [
         "arm64"
       ],
@@ -1399,9 +1424,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
       "cpu": [
         "arm64"
       ],
@@ -1413,9 +1438,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
       "cpu": [
         "x64"
       ],
@@ -1427,9 +1452,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
       "cpu": [
         "arm64"
       ],
@@ -1441,9 +1466,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
       "cpu": [
         "x64"
       ],
@@ -1455,9 +1480,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
       "cpu": [
         "arm"
       ],
@@ -1469,9 +1494,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
       "cpu": [
         "arm"
       ],
@@ -1483,9 +1508,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
       "cpu": [
         "arm64"
       ],
@@ -1497,9 +1522,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
       "cpu": [
         "arm64"
       ],
@@ -1511,9 +1536,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
       "cpu": [
         "loong64"
       ],
@@ -1525,9 +1550,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
       "cpu": [
         "loong64"
       ],
@@ -1539,9 +1564,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
       "cpu": [
         "ppc64"
       ],
@@ -1553,9 +1578,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
       "cpu": [
         "ppc64"
       ],
@@ -1567,9 +1592,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
       "cpu": [
         "riscv64"
       ],
@@ -1581,9 +1606,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1595,9 +1620,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
       "cpu": [
         "s390x"
       ],
@@ -1609,9 +1634,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
       "cpu": [
         "x64"
       ],
@@ -1623,9 +1648,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
       "cpu": [
         "x64"
       ],
@@ -1637,9 +1662,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
       "cpu": [
         "x64"
       ],
@@ -1651,9 +1676,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
       "cpu": [
         "arm64"
       ],
@@ -1665,9 +1690,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
       "cpu": [
         "arm64"
       ],
@@ -1679,9 +1704,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
       "cpu": [
         "ia32"
       ],
@@ -1693,9 +1718,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
       "cpu": [
         "x64"
       ],
@@ -1707,9 +1732,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
       "cpu": [
         "x64"
       ],
@@ -1721,9 +1746,9 @@
       ]
     },
     "node_modules/@tiptap/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-XKZYrCVFsyQGF6dXQR73YR222l/76wkKfZ+2/4LCrem5qtcOarmv5pYxjUBG8mRuBPskTTBImSFTeQltJIUNCg==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1732,13 +1757,169 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.6.2"
+        "@tiptap/pm": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.26.0.tgz",
+      "integrity": "sha512-57accpka9affjiJRjP2LMNCDJDTMjTvO23RJCxtP43sp9cTIZ7YZnyDfRxCINTRBNK0X4o4w2+emOLyRwsk3CA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.26.0.tgz",
+      "integrity": "sha512-j6CzTMofcGJ5iMoUgDRQpM0FkG00jBID3aKqs+UBbgtzLgtG/CI/91tMFv0XPC30LeFA895qYgvGZtHdejZhiQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.26.0.tgz",
+      "integrity": "sha512-Jv7BX+kBB2wUIvO/NhuUjv+T3kAed2Tjr664fgQ2zKT6X69jKIkYuCCedrIHuOyaOQ+SBDuH9h51wYv/E97QgQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.26.0.tgz",
+      "integrity": "sha512-VJYcV6rvjnENRTroOi9tDcHWW6G0pmCoRETwatlbgfDzuCmkTOwVwQjeJCXOVMMLNPzNiXZzibsRCUt+Azq/jw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.26.0.tgz",
+      "integrity": "sha512-WPN9iZ3UjeDD2ckDzSs9tleibXv0cLj7j575NxuvjhwZTehYGNeYDSUTi+6DQUG6bKbhGg9Wcei5H0131vvJHg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.26.0.tgz",
+      "integrity": "sha512-Xhd6DCjaxCN4otQNvV6qra+XuoIjk6Vyjm87E5xn5Y/BMw7UGAG7LTkk3C2IEvxKrVZwJjalfxEqdHOgXQzVfw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.26.0.tgz",
+      "integrity": "sha512-rhAtp5J/YVDUCUIc5T7b0XY9dLeuI72JgOr53w0QQc0VA0uwbfTn7sx0LI9PDCE9uwmDH8H3snVRZRnAvlM8oA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.26.0.tgz",
+      "integrity": "sha512-SIe68SDwx2fozt/XKG0FhCwzz/yRN6Bvo4D5TqvfDg6NK3PQb1DS4GN9PilmJqbY+kXryuiWEEJOWi7HpO8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.26.0.tgz",
+      "integrity": "sha512-baXvv/rtOTVd2Axjb7Zbb41Y9Qmy3U2fP7EHqLuhViqGxVX8LwQtP0PHUXEZkPokbBpRez10+dmOlvvsYFKAZQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.26.0.tgz",
+      "integrity": "sha512-qenEQEgzE5FjQay/H6iKOnwIt6DPO27cS+v0mGhXmrL1MjrNER4X0ZkATJbVd0WA6ffsAGaP44NKYDworGeidw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.26.0.tgz",
+      "integrity": "sha512-a+N/C4wkQV+/8x4ShdoiC2JdTW3Tw84C5cAloYLFMeaWmRa2me9ACSI+zo0SO9bbH9RJwsoRp7eaxBbk27eF1Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.6.2.tgz",
-      "integrity": "sha512-AuetGUr1sGH18UDREk0EMt7jYnFkBFsnYlXNNcp0g0rGACRKaCD7Bzv451nHc8m1WYOpqMAyTTlRg+eYs442xA==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.26.0.tgz",
+      "integrity": "sha512-vinrbKa9Awmlb/UPpnes1pezL+ZeUC2v7XczZyNbggvcHKhlVkuXZIKytFQDXEYOTaKYzYE8B/Gz098PiJ9NYQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1747,13 +1928,131 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.6.2"
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.26.0.tgz",
+      "integrity": "sha512-s8oFpH+0xmhvY19f452/2dExO3p1tjxh761g6cg4irwEUNUEAJKF2VLcjiaeOhNJ+pmnQYxb+VSkwkXvO+7vHQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.26.0.tgz",
+      "integrity": "sha512-FA/d157aBxyvZFvsdc5eSu46tmHWXebAsqOQSvivOMyw+deBb00VlMsf+iD2J8+sekjbMYwx/hvbsu+xUoX43Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.26.0.tgz",
+      "integrity": "sha512-EM8woyHDNKLEQ+lWUEoDtA4KrwP6fei/mYX1NxseMzKHHo7LFecx7wk6sovAXZrUvdML/yFBihgiMiO5VIsfkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.26.0.tgz",
+      "integrity": "sha512-MccGyj9HY4fkl04eIiFoTCkr8067Jku/VVdJNtRWW104Spx43C/7V2zpbxPvpcDhq3dW384fDxYXfpnb186xLg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.26.0.tgz",
+      "integrity": "sha512-oBcj6qaNrRHQ+N0+pDuOVAQa4Nx9r8Cm5ANvyM2lTpoy60sOLOizuVvcvw1andVxbSrsZ1N/Sk+RZWyv1uoWyQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.26.0.tgz",
+      "integrity": "sha512-ItLdFlcMsJz2vhbs1PcUfcN7nzVqGBOwPeCrrWxjrgscp+K3JoOGD+HhVVpBACOMwivUrlh8Ry5Ohvues2nOeA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.26.0.tgz",
+      "integrity": "sha512-h8fYLikg4qN39IghQ1y9g+zzUsgxBpDi5YS3IZbWoxWYYx1YqLL8nAvOiPr7Us14aQ0TjA2/xY7zqmyf29rX1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.26.0.tgz",
+      "integrity": "sha512-jUll3Pqhq7u1JKvO0B6USW/bmVmUsO6sRcxo/d5tXqLhS0tWAobOGoGU2IgwXnQDSjf+vF73RYD5tRGDLkRC9Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
       }
     },
     "node_modules/@tiptap/extension-subscript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.6.2.tgz",
-      "integrity": "sha512-knI9mlRPwRSTza8y5K7x3w3Lg/m5dXAqbxpjCwTxEzu3ngbaUyLEDfQ4TCViwgqCWTefDtPI/FEiKl1MTVcw9g==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.26.0.tgz",
+      "integrity": "sha512-6H4otLGtA2t2w/k4YxtUaDve+OV1ARUwJY2CDvOJrUWIUMCexCe6ppqR2ZAxkyGMa5TLHqgS0+7Z2wjrjERVPw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1762,14 +2061,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.6.2",
-        "@tiptap/pm": "^3.6.2"
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
       }
     },
     "node_modules/@tiptap/extension-superscript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.6.2.tgz",
-      "integrity": "sha512-DbxTVrbX6cYSn8vSQ0kScgJ37x3EzNX6a83XO1OhByH3pH1oPqZyzBtLLNt5ocaMFQHEGawhwoGjNpzOCSoajA==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.26.0.tgz",
+      "integrity": "sha512-pewb9auEW6ZXZFZK4SacaLDj/qah8Ob4eVKUwW7dLjC6ga9UQmlhMnI/YhgB68qfbKxq7g4oYpHYj1zmU/74EQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1778,14 +2077,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.6.2",
-        "@tiptap/pm": "^3.6.2"
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
       }
     },
     "node_modules/@tiptap/extension-table": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.6.2.tgz",
-      "integrity": "sha512-ozRPpxTXrYABTU/zQq3JlytUUXvQDaEcl19YUR1mL/7Ctf4zRBvSnBHCuP/1Cu+4oHX4zdako/G++Z5qJxa65A==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.26.0.tgz",
+      "integrity": "sha512-pLL1+tKeUWSF/w4se84tjWUnuraKVELQtIHwi1XKoq6vkevotwwMb99xY6cJ752FaUFVDbViFe/JUYWBoU+bIw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1794,14 +2093,28 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.6.2",
-        "@tiptap/pm": "^3.6.2"
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.26.0.tgz",
+      "integrity": "sha512-yZXdevp3/8omGbb40Z52VfvID+tsRNhPQ1GNUToD56XSr2BjdJyAzAb9rWGgDKgVMUPLgJ26yT0O278RFqOKhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
       }
     },
     "node_modules/@tiptap/extension-text-align": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.6.2.tgz",
-      "integrity": "sha512-P3IYe6pyOe9hZoSQfHypFioLbGrr24d55/RkvNnwSd8qzd0RhjXIyiuOmYLcXdLio4PkJ+KjbZcptQ9zW8Mh4g==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.26.0.tgz",
+      "integrity": "sha512-yEtgrEJyE7sfcIAzk9cmJUQUMQZ/J0RU3k7mE+hy5o7t8j78Zs+KcsH+hrczn0MNzblg4gfX2erN+1/SGfSlpA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1810,13 +2123,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.6.2"
+        "@tiptap/core": "3.26.0"
       }
     },
     "node_modules/@tiptap/extension-text-style": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.6.2.tgz",
-      "integrity": "sha512-1N5suFcjZLdccYN+5zjFGFPV6YsLWbz0aYnLcwUvrRSxMm5VkOqKSm5ZLV11rikU06WgkfpLCtmZ5jpl0piD9Q==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.26.0.tgz",
+      "integrity": "sha512-4IeIdiubF5/Em9AodaLkCKUNwkQaK3KuwnneXS61x4Yoyr0zK21i3kZAFK7ils7jUwSrRdGdM1FglBnB4tK8nA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1825,13 +2138,27 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.6.2"
+        "@tiptap/core": "3.26.0"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.26.0.tgz",
+      "integrity": "sha512-LlVkivH5cBwov/EMD8BL7ZRcU6YcadiSVIffLW1hyalw9YfhaFzoLxjtWhL7jiU/n2Kg+9dXSZxmV2hTeTwyrQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.6.2.tgz",
-      "integrity": "sha512-tg7/DgaI6SpkeawryapUtNoBxsJUMJl3+nSjTfTvsaNXed+BHzLPsvmPbzlF9ScrAbVEx8nj6CCkneECYIQ4CQ==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.26.0.tgz",
+      "integrity": "sha512-4wajuqnO2X0+LVvsBjW/xk3/tmdb16bNL939QhicAay4YYqXITeV2v3XJsryzmG4L5GkK1yLxvRGk4aLoxWrnA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1840,36 +2167,31 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.6.2",
-        "@tiptap/pm": "^3.6.2"
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.6.2.tgz",
-      "integrity": "sha512-g+NXjqjbj6NfHOMl22uNWVYIu8oCq7RFfbnpohPMsSKJLaHYE8mJR++7T6P5R9FoqhIFdwizg1jTpwRU5CHqXQ==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.26.0.tgz",
+      "integrity": "sha512-q4RDeWwVrhOL0jJCGRgGxLSdjOYwzQ4h2InURZVhC66433ipcHd6f3bqSOhcXZ4r0sFmMNsuF7aZmUntjWLc7w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
         "prosemirror-commands": "^1.6.2",
         "prosemirror-dropcursor": "^1.8.1",
         "prosemirror-gapcursor": "^1.3.2",
         "prosemirror-history": "^1.4.1",
         "prosemirror-inputrules": "^1.4.0",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.7",
         "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.0",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.8"
       },
       "funding": {
         "type": "github",
@@ -1877,401 +2199,37 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.6.2.tgz",
-      "integrity": "sha512-nPzraIx/f1cOUNqG1LSC0OTnEu3mudcN3jQVuyGh3dvdOnik7FUciJEVfHKnloAyeoijidEeiLpiGHInp2uREg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tiptap/core": "^3.6.2",
-        "@tiptap/extension-blockquote": "^3.6.2",
-        "@tiptap/extension-bold": "^3.6.2",
-        "@tiptap/extension-bullet-list": "^3.6.2",
-        "@tiptap/extension-code": "^3.6.2",
-        "@tiptap/extension-code-block": "^3.6.2",
-        "@tiptap/extension-document": "^3.6.2",
-        "@tiptap/extension-dropcursor": "^3.6.2",
-        "@tiptap/extension-gapcursor": "^3.6.2",
-        "@tiptap/extension-hard-break": "^3.6.2",
-        "@tiptap/extension-heading": "^3.6.2",
-        "@tiptap/extension-horizontal-rule": "^3.6.2",
-        "@tiptap/extension-italic": "^3.6.2",
-        "@tiptap/extension-link": "^3.6.2",
-        "@tiptap/extension-list": "^3.6.2",
-        "@tiptap/extension-list-item": "^3.6.2",
-        "@tiptap/extension-list-keymap": "^3.6.2",
-        "@tiptap/extension-ordered-list": "^3.6.2",
-        "@tiptap/extension-paragraph": "^3.6.2",
-        "@tiptap/extension-strike": "^3.6.2",
-        "@tiptap/extension-text": "^3.6.2",
-        "@tiptap/extension-underline": "^3.6.2",
-        "@tiptap/extensions": "^3.6.2",
-        "@tiptap/pm": "^3.6.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/core": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.10.7.tgz",
-      "integrity": "sha512-4rD3oHkXNOS6Fxm0mr+ECyq35iMFnnAXheIO+UsQbOexwTxn2yZ5Q1rQiFKcCf+p+rrg1yt8TtxQPM8VLWS+1g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/pm": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-blockquote": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.10.7.tgz",
-      "integrity": "sha512-xIeRVTnnC78VDgm3YxosgM1ODVKBdmyWuz4Dhhyc1UCPFptzNIPZuzNbOxyThFseqKh1LVDM+EmjshACE/3jVg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-bold": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.10.7.tgz",
-      "integrity": "sha512-NWjOIIZdxUSkWLQrEY4Tg60MzS6RGt/1aLnwTyFFzFFShzOmd/xzxp0fRS+p79ZKNcQa9OKgnrlS4xuRq8WOdQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.10.7.tgz",
-      "integrity": "sha512-c6ycK/8TZEl8sw4Wkr4APpjeNaNhh4EJPBZ2bt4oHqkl+v5NCddo9xdP1sgsopNySPNQaHQSO5GYmU2QHbSBpA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-code": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.10.7.tgz",
-      "integrity": "sha512-POK3CCy29LoRI6JVvFRVAmH2G90a7pKJT8sbqOaX1WKmLLDt7drUxGgBNnz/cBXJQHPnXZgRq/P8ZQPISklT7Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-code-block": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.10.7.tgz",
-      "integrity": "sha512-Z6EH/DhSVQtOKL+vS9J2dbvJ81T3xJ2Htgn4BOxpuCGUCInu5Aymf/53tco3aQse/UHB3Gvr+/4AOwxphXYhgw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7",
-        "@tiptap/pm": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-document": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.10.7.tgz",
-      "integrity": "sha512-RlezqyAf0voUblrMLArh+AZJ9t+rE6buFa+U1V37Ey+I1z+Y8pPqlhtYJoTUz0GtSZWMReirSvoQpQJHM9x3Yw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.10.7.tgz",
-      "integrity": "sha512-VnI+lRpXi9Qa/RFeZYqGd5taApM8SD6qYBnL1FqwRx7eLpWH3UyH911d9/sFqYxouDy06XRDHPoqlyMw5afdwQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.10.7.tgz",
-      "integrity": "sha512-1VDNX+4ZCKxuoj6nRTZDwHjPYhuSdELYYCSfxscojlwexPxCLcgqOt71xdgnQXW5Hv6ACT4OrGGYcGTupudOHg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-hard-break": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.10.7.tgz",
-      "integrity": "sha512-EIdTsD2pV4FSef/6nrKlXV8H5861PElnIjuoHkwk1alowAVL/HSvJqPxZwH6k2qLcsabkr0cSdaDixw9gJGAdg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-heading": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.10.7.tgz",
-      "integrity": "sha512-Pp0LYTEyimDfiXzy+8Ls2LDuhhmyM7jXr8go3myTHSLMTpt0ch7P5FVSnDxMFtQ5eRiAwXHET63/JOaiIwMa/w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.10.7.tgz",
-      "integrity": "sha512-V9uWb341QUBDDbR3aoSs3Sx0PQQaKwZ/ESVEE03El9rkIrf8g5K82x8/M0nvSOvGobt6oRyI/rgbj196YQuXiQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7",
-        "@tiptap/pm": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-italic": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.10.7.tgz",
-      "integrity": "sha512-1CQgHNm51xDyZI188f5xKLcUIjRS+2cyZgS9XwKwIU/3QOsiKsNC+cBc4VmN3aR0A01NjK0ch0MjeKkPPWUt5A==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-link": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.10.7.tgz",
-      "integrity": "sha512-AIgrtveTQ5QyRpcic2MVSuv9aOaN0n+swdZPvi8XREZX/uf1SU4dYU7p0dNChhcn53GGPDNVRTQXX4YdEAZFQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "linkifyjs": "^4.3.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7",
-        "@tiptap/pm": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.10.7.tgz",
-      "integrity": "sha512-aggic/94+wAt50Bx492++YsQtu0NdH8psaRokA0/9NvTjHoLq/zbbyloJyYW+DWe4GzwK9qCB5PKHQTTXWMu9Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7",
-        "@tiptap/pm": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list-item": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.10.7.tgz",
-      "integrity": "sha512-beCOcDfOzCY9/7fAHY/O/RFcqxLPJWGBV/6YMMUkyW34rrb1NmSZp2qegTh+1820DHs7sokn/OeCIo8Fqs8lQA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.10.7.tgz",
-      "integrity": "sha512-QzDX+BY3z60sz3GfMK7oQV/CnAL0elRI+VdGyObuNS/RCpD6DKwa5Gb+vB9Qj3sUccViJOhBr8OpmLDtAoco8g==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.10.7.tgz",
-      "integrity": "sha512-+rcJM0iqBVHBRlbupU8KmoTc3AD8maWJyQl05LrVQcAwmRDx3xtIagRnN1hwxSYavIFRwLATgYHSWd08nnL38g==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-paragraph": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.10.7.tgz",
-      "integrity": "sha512-53+nCxNaKcmeqQ+aWrSauEWywuWPp8qkUTOO2rHlpmM+rk/1bv3IZePKQ2JtHZzYCeRd3xOC33kl60HE7EwakQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-strike": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.10.7.tgz",
-      "integrity": "sha512-pZMdQhChv59jsahvmjiJjSTPM05J6EHAX/GPdA9w8xSKy73899MhIhWJ7yt2CJEPjwn3ixnomIPhMjxBkizv+g==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-text": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.10.7.tgz",
-      "integrity": "sha512-b7Rjil/uqiabWnRHyd1P84rWD2XRyZZSrmIAO9mDMD/jB2bE+f7rDJcHG76GF03UicDhEEEf2/8mz0dMLa6mUA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-underline": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.10.7.tgz",
-      "integrity": "sha512-yBL81xdbjT5Y7acoBqWpnH/SoH3bpgqaLvJBG3NNk+mdLB5HjBWTlPLKjvjQV0HRN5bZ+RJWeiRnQk1ahcfmQA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extensions": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.10.7.tgz",
-      "integrity": "sha512-jYYR7NA7t2hdyJmSLYVAJ3usyIOZ2mfFqPCCHbSn/k3jqmGaPFZuxJSwmYjfmTxisZ9rGn+49/YJF2y/Yej/0Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.10.7",
-        "@tiptap/pm": "^3.10.7"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/pm": {
-      "version": "3.10.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.10.7.tgz",
-      "integrity": "sha512-/iiurioqSukJk6CrEtfRpdOEafDybyVPToAllgn7i2XcusXSxJSX+K0GUndMUwVR+UqVOCyMYBTRTnE0hdQqgA==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.26.0.tgz",
+      "integrity": "sha512-o34EtMfqtBaljdmeElZsRG/067oGx9Zcq+j2GWo71KlZe22ga/ALexeTf1c+ETsjCxSTKR6eyQ4RZvz/2JpYfg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
-        "prosemirror-commands": "^1.6.2",
-        "prosemirror-dropcursor": "^1.8.1",
-        "prosemirror-gapcursor": "^1.3.2",
-        "prosemirror-history": "^1.4.1",
-        "prosemirror-inputrules": "^1.4.0",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
-        "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
+        "@tiptap/core": "^3.26.0",
+        "@tiptap/extension-blockquote": "^3.26.0",
+        "@tiptap/extension-bold": "^3.26.0",
+        "@tiptap/extension-bullet-list": "^3.26.0",
+        "@tiptap/extension-code": "^3.26.0",
+        "@tiptap/extension-code-block": "^3.26.0",
+        "@tiptap/extension-document": "^3.26.0",
+        "@tiptap/extension-dropcursor": "^3.26.0",
+        "@tiptap/extension-gapcursor": "^3.26.0",
+        "@tiptap/extension-hard-break": "^3.26.0",
+        "@tiptap/extension-heading": "^3.26.0",
+        "@tiptap/extension-horizontal-rule": "^3.26.0",
+        "@tiptap/extension-italic": "^3.26.0",
+        "@tiptap/extension-link": "^3.26.0",
+        "@tiptap/extension-list": "^3.26.0",
+        "@tiptap/extension-list-item": "^3.26.0",
+        "@tiptap/extension-list-keymap": "^3.26.0",
+        "@tiptap/extension-ordered-list": "^3.26.0",
+        "@tiptap/extension-paragraph": "^3.26.0",
+        "@tiptap/extension-strike": "^3.26.0",
+        "@tiptap/extension-text": "^3.26.0",
+        "@tiptap/extension-underline": "^3.26.0",
+        "@tiptap/extensions": "^3.26.0",
+        "@tiptap/pm": "^3.26.0"
       },
       "funding": {
         "type": "github",
@@ -2286,9 +2244,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2412,9 +2370,9 @@
       "peer": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2499,9 +2457,9 @@
       "license": "MIT"
     },
     "node_modules/@types/koa": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
-      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.2.tgz",
+      "integrity": "sha512-CB+iyjjh1uS5N6/CKwXvw0qA7USMS2WVc4Tjf660yCjhdvqzNr8gdFcIawB41zGGptOQ+d1fnpaQWIIUXYxR3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2525,31 +2483,6 @@
         "@types/koa": "*"
       }
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
@@ -2558,13 +2491,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/parse5": {
@@ -2575,9 +2508,9 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2616,10 +2549,20 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sinon": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
-      "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
+      "integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2679,9 +2622,9 @@
       }
     },
     "node_modules/@umbraco-cms/backoffice": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.0.0.tgz",
-      "integrity": "sha512-8gVpB5AjXIEhPBF/Wh3peXlLMNsP/Yd+GuAQ+AEPdvdHNoJGGAJt9flKyKvorvMzZvYnVHS9n+8M25lBLY2RBw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.4.2.tgz",
+      "integrity": "sha512-fVMoBVETch4hs78fV6b44no2UrtFNnZr/Yt7u/oVDjbmlk3PaybcAXHLAz+DjqYHth1czvfESzDK7vou4BpTtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2689,172 +2632,172 @@
         "npm": ">=10.9.2"
       },
       "peerDependencies": {
-        "@heximal/expressions": "^0.1.5",
-        "@hey-api/openapi-ts": "^0.85.0",
+        "@heximal/expressions": ">=0.1.5 <1.0.0",
+        "@hey-api/openapi-ts": ">=0.85.2 <1.0.0",
         "@microsoft/signalr": "^10.0.0",
-        "@tiptap/core": "3.6.2",
-        "@tiptap/extension-image": "3.6.2",
-        "@tiptap/extension-subscript": "3.6.2",
-        "@tiptap/extension-superscript": "3.6.2",
-        "@tiptap/extension-table": "3.6.2",
-        "@tiptap/extension-text-align": "3.6.2",
-        "@tiptap/extension-text-style": "3.6.2",
-        "@tiptap/extensions": "3.6.2",
-        "@tiptap/pm": "3.6.2",
-        "@tiptap/starter-kit": "3.6.2",
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/extension-image": "^3.22.3",
+        "@tiptap/extension-subscript": "^3.22.3",
+        "@tiptap/extension-superscript": "^3.22.3",
+        "@tiptap/extension-table": "^3.22.3",
+        "@tiptap/extension-text-align": "^3.22.3",
+        "@tiptap/extension-text-style": "^3.22.3",
+        "@tiptap/extensions": "^3.22.3",
+        "@tiptap/pm": "^3.22.3",
+        "@tiptap/starter-kit": "^3.22.3",
         "@types/diff": "^7.0.2",
-        "@umbraco-ui/uui": "^1.16.0",
-        "@umbraco-ui/uui-css": "^1.16.0",
-        "diff": "^7.0.0",
-        "dompurify": "^3.2.7",
+        "@umbraco-ui/uui": "^1.17.3",
+        "@umbraco-ui/uui-css": "^1.17.3",
+        "diff": "^9.0.0",
+        "dompurify": "^3.4.0",
         "element-internals-polyfill": "^3.0.2",
         "lit": "^3.3.1",
         "luxon": "^3.7.2",
-        "marked": "^17.0.1",
-        "monaco-editor": "^0.54.0",
+        "marked": "^18.0.0",
+        "monaco-editor": ">=0.55.1 <1.0.0",
         "rxjs": "^7.8.2",
         "uuid": "^13.0.0"
       }
     },
     "node_modules/@umbraco-ui/uui": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.16.0.tgz",
-      "integrity": "sha512-aWHFSTf+FkPiMirT25UjmUD7wcyQqxvO7btO3AeA7Ogx7R3KiVNulHpPNPgTsyaHFWRcVmxhWDHaib4GHoOJXQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.18.0.tgz",
+      "integrity": "sha512-4gFmkeM/+h1w1k/g3GbhAuzY1cS4+Vg0TvXXyVY9J2d/0llhT60Mv0/HhlvDmooALUdb4ECNOwILtfG0x4MyTA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.16.0",
-        "@umbraco-ui/uui-avatar": "1.16.0",
-        "@umbraco-ui/uui-avatar-group": "1.16.0",
-        "@umbraco-ui/uui-badge": "1.16.0",
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-boolean-input": "1.16.0",
-        "@umbraco-ui/uui-box": "1.16.0",
-        "@umbraco-ui/uui-breadcrumbs": "1.16.0",
-        "@umbraco-ui/uui-button": "1.16.0",
-        "@umbraco-ui/uui-button-copy-text": "1.16.0",
-        "@umbraco-ui/uui-button-group": "1.16.0",
-        "@umbraco-ui/uui-button-inline-create": "1.16.0",
-        "@umbraco-ui/uui-card": "1.16.0",
-        "@umbraco-ui/uui-card-block-type": "1.16.0",
-        "@umbraco-ui/uui-card-content-node": "1.16.0",
-        "@umbraco-ui/uui-card-media": "1.16.0",
-        "@umbraco-ui/uui-card-user": "1.16.0",
-        "@umbraco-ui/uui-caret": "1.16.0",
-        "@umbraco-ui/uui-checkbox": "1.16.0",
-        "@umbraco-ui/uui-color-area": "1.16.0",
-        "@umbraco-ui/uui-color-picker": "1.16.0",
-        "@umbraco-ui/uui-color-slider": "1.16.0",
-        "@umbraco-ui/uui-color-swatch": "1.16.0",
-        "@umbraco-ui/uui-color-swatches": "1.16.0",
-        "@umbraco-ui/uui-combobox": "1.16.0",
-        "@umbraco-ui/uui-combobox-list": "1.16.0",
-        "@umbraco-ui/uui-css": "1.16.0",
-        "@umbraco-ui/uui-dialog": "1.16.0",
-        "@umbraco-ui/uui-dialog-layout": "1.16.0",
-        "@umbraco-ui/uui-file-dropzone": "1.16.0",
-        "@umbraco-ui/uui-file-preview": "1.16.0",
-        "@umbraco-ui/uui-form": "1.16.0",
-        "@umbraco-ui/uui-form-layout-item": "1.16.0",
-        "@umbraco-ui/uui-form-validation-message": "1.16.0",
-        "@umbraco-ui/uui-icon": "1.16.0",
-        "@umbraco-ui/uui-icon-registry": "1.16.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
-        "@umbraco-ui/uui-input": "1.16.0",
-        "@umbraco-ui/uui-input-file": "1.16.0",
-        "@umbraco-ui/uui-input-lock": "1.16.0",
-        "@umbraco-ui/uui-input-password": "1.16.0",
-        "@umbraco-ui/uui-keyboard-shortcut": "1.16.0",
-        "@umbraco-ui/uui-label": "1.16.0",
-        "@umbraco-ui/uui-loader": "1.16.0",
-        "@umbraco-ui/uui-loader-bar": "1.16.0",
-        "@umbraco-ui/uui-loader-circle": "1.16.0",
-        "@umbraco-ui/uui-menu-item": "1.16.0",
-        "@umbraco-ui/uui-modal": "1.16.0",
-        "@umbraco-ui/uui-pagination": "1.16.0",
-        "@umbraco-ui/uui-popover": "1.16.0",
-        "@umbraco-ui/uui-popover-container": "1.16.0",
-        "@umbraco-ui/uui-progress-bar": "1.16.0",
-        "@umbraco-ui/uui-radio": "1.16.0",
-        "@umbraco-ui/uui-range-slider": "1.16.0",
-        "@umbraco-ui/uui-ref": "1.16.0",
-        "@umbraco-ui/uui-ref-list": "1.16.0",
-        "@umbraco-ui/uui-ref-node": "1.16.0",
-        "@umbraco-ui/uui-ref-node-data-type": "1.16.0",
-        "@umbraco-ui/uui-ref-node-document-type": "1.16.0",
-        "@umbraco-ui/uui-ref-node-form": "1.16.0",
-        "@umbraco-ui/uui-ref-node-member": "1.16.0",
-        "@umbraco-ui/uui-ref-node-package": "1.16.0",
-        "@umbraco-ui/uui-ref-node-user": "1.16.0",
-        "@umbraco-ui/uui-scroll-container": "1.16.0",
-        "@umbraco-ui/uui-select": "1.16.0",
-        "@umbraco-ui/uui-slider": "1.16.0",
-        "@umbraco-ui/uui-symbol-expand": "1.16.0",
-        "@umbraco-ui/uui-symbol-file": "1.16.0",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.16.0",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.16.0",
-        "@umbraco-ui/uui-symbol-folder": "1.16.0",
-        "@umbraco-ui/uui-symbol-lock": "1.16.0",
-        "@umbraco-ui/uui-symbol-more": "1.16.0",
-        "@umbraco-ui/uui-symbol-sort": "1.16.0",
-        "@umbraco-ui/uui-table": "1.16.0",
-        "@umbraco-ui/uui-tabs": "1.16.0",
-        "@umbraco-ui/uui-tag": "1.16.0",
-        "@umbraco-ui/uui-textarea": "1.16.0",
-        "@umbraco-ui/uui-toast-notification": "1.16.0",
-        "@umbraco-ui/uui-toast-notification-container": "1.16.0",
-        "@umbraco-ui/uui-toast-notification-layout": "1.16.0",
-        "@umbraco-ui/uui-toggle": "1.16.0",
-        "@umbraco-ui/uui-visually-hidden": "1.16.0"
+        "@umbraco-ui/uui-action-bar": "1.18.0",
+        "@umbraco-ui/uui-avatar": "1.18.0",
+        "@umbraco-ui/uui-avatar-group": "1.18.0",
+        "@umbraco-ui/uui-badge": "1.18.0",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-boolean-input": "1.18.0",
+        "@umbraco-ui/uui-box": "1.18.0",
+        "@umbraco-ui/uui-breadcrumbs": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-button-copy-text": "1.18.0",
+        "@umbraco-ui/uui-button-group": "1.18.0",
+        "@umbraco-ui/uui-button-inline-create": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0",
+        "@umbraco-ui/uui-card-block-type": "1.18.0",
+        "@umbraco-ui/uui-card-content-node": "1.18.0",
+        "@umbraco-ui/uui-card-media": "1.18.0",
+        "@umbraco-ui/uui-card-user": "1.18.0",
+        "@umbraco-ui/uui-caret": "1.18.0",
+        "@umbraco-ui/uui-checkbox": "1.18.0",
+        "@umbraco-ui/uui-color-area": "1.18.0",
+        "@umbraco-ui/uui-color-picker": "1.18.0",
+        "@umbraco-ui/uui-color-slider": "1.18.0",
+        "@umbraco-ui/uui-color-swatch": "1.18.0",
+        "@umbraco-ui/uui-color-swatches": "1.18.0",
+        "@umbraco-ui/uui-combobox": "1.18.0",
+        "@umbraco-ui/uui-combobox-list": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0",
+        "@umbraco-ui/uui-dialog": "1.18.0",
+        "@umbraco-ui/uui-dialog-layout": "1.18.0",
+        "@umbraco-ui/uui-file-dropzone": "1.18.0",
+        "@umbraco-ui/uui-file-preview": "1.18.0",
+        "@umbraco-ui/uui-form": "1.18.0",
+        "@umbraco-ui/uui-form-layout-item": "1.18.0",
+        "@umbraco-ui/uui-form-validation-message": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-icon-registry": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0",
+        "@umbraco-ui/uui-input": "1.18.0",
+        "@umbraco-ui/uui-input-file": "1.18.0",
+        "@umbraco-ui/uui-input-lock": "1.18.0",
+        "@umbraco-ui/uui-input-password": "1.18.0",
+        "@umbraco-ui/uui-keyboard-shortcut": "1.18.0",
+        "@umbraco-ui/uui-label": "1.18.0",
+        "@umbraco-ui/uui-loader": "1.18.0",
+        "@umbraco-ui/uui-loader-bar": "1.18.0",
+        "@umbraco-ui/uui-loader-circle": "1.18.0",
+        "@umbraco-ui/uui-menu-item": "1.18.0",
+        "@umbraco-ui/uui-modal": "1.18.0",
+        "@umbraco-ui/uui-pagination": "1.18.0",
+        "@umbraco-ui/uui-popover": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
+        "@umbraco-ui/uui-progress-bar": "1.18.0",
+        "@umbraco-ui/uui-radio": "1.18.0",
+        "@umbraco-ui/uui-range-slider": "1.18.0",
+        "@umbraco-ui/uui-ref": "1.18.0",
+        "@umbraco-ui/uui-ref-list": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0",
+        "@umbraco-ui/uui-ref-node-data-type": "1.18.0",
+        "@umbraco-ui/uui-ref-node-document-type": "1.18.0",
+        "@umbraco-ui/uui-ref-node-form": "1.18.0",
+        "@umbraco-ui/uui-ref-node-member": "1.18.0",
+        "@umbraco-ui/uui-ref-node-package": "1.18.0",
+        "@umbraco-ui/uui-ref-node-user": "1.18.0",
+        "@umbraco-ui/uui-scroll-container": "1.18.0",
+        "@umbraco-ui/uui-select": "1.18.0",
+        "@umbraco-ui/uui-slider": "1.18.0",
+        "@umbraco-ui/uui-symbol-expand": "1.18.0",
+        "@umbraco-ui/uui-symbol-file": "1.18.0",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.18.0",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.18.0",
+        "@umbraco-ui/uui-symbol-folder": "1.18.0",
+        "@umbraco-ui/uui-symbol-lock": "1.18.0",
+        "@umbraco-ui/uui-symbol-more": "1.18.0",
+        "@umbraco-ui/uui-symbol-sort": "1.18.0",
+        "@umbraco-ui/uui-table": "1.18.0",
+        "@umbraco-ui/uui-tabs": "1.18.0",
+        "@umbraco-ui/uui-tag": "1.18.0",
+        "@umbraco-ui/uui-textarea": "1.18.0",
+        "@umbraco-ui/uui-toast-notification": "1.18.0",
+        "@umbraco-ui/uui-toast-notification-container": "1.18.0",
+        "@umbraco-ui/uui-toast-notification-layout": "1.18.0",
+        "@umbraco-ui/uui-toggle": "1.18.0",
+        "@umbraco-ui/uui-visually-hidden": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-action-bar": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.16.0.tgz",
-      "integrity": "sha512-WM08j2cGcJcbXWS6Pb9FdhaKDz3+EUSuoxrsZoGkJBJMriZLv4gq9EcE5RIstUbT8JmDPQ7uT3SDT2gZWl07MQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.18.0.tgz",
+      "integrity": "sha512-8nGvHoqXuGoLkQXcW5KbMi64wDEhUaoPi4DEIOt7WcmqJOV9Bjc7zbwwBxUfcqVqbCQj884xQqQDKrCTuhp1GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-button-group": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button-group": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-avatar": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.16.0.tgz",
-      "integrity": "sha512-1u6+hOLy5NrFh5/Z4Kp88y3Mhq+FYCZRwPb+5lSutm+aMy27dehRKkZqlbptWn/qocUCibDxQpruvu/UMtVQtg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.18.0.tgz",
+      "integrity": "sha512-PKsDmvVML7iWOZhQOCFGTSxaZ2R91/6sdcQ0awdzD3bB9CAdKExYvcFyO70TPaZRoFnXs44tQfozp0F4uLIMGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-avatar-group": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.16.0.tgz",
-      "integrity": "sha512-509UZzUSD/JhJEVLEpT5ltccHpEw8RxoZbG+hJeg23Oh3jNuRrKvuiyOut5c6JfjMdawHw6vPivVwjqCmbZG5g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.18.0.tgz",
+      "integrity": "sha512-ddDPB3CMW9peXwiO0bDcvDSnc1loXMjF6JJxg9P6oGXEvb/BNoopnVFB638GCWrNJzJ5BBB0lO5HACb10HgmGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.16.0",
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-avatar": "1.18.0",
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-badge": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.16.0.tgz",
-      "integrity": "sha512-sHo71JOxxk0EufgYfCl9miuYgM1LDSnmtHedvDGs776htMFkLo3W/cFWgIXabAHZeSj4R5UWMGDNsugwv03R+w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.18.0.tgz",
+      "integrity": "sha512-G9qwSc6rnYUhF8PLBsUOXsOYkrA/pGN/MMHUJd/5+wKjhNvcO6qcQYsVQtAGsTLhEyq2AplxzRHtmiVD0fWnPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-base": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.16.0.tgz",
-      "integrity": "sha512-8i9bdcSrdR/4lWm0xetr3R3w3Rod3YVbIddHqbb3iVrr0TmPDTVA48tnOsJyQFAvTrh2LZjiETvEve7pBy4WQA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.18.0.tgz",
+      "integrity": "sha512-bsy+pIQgkRZleTOmi7v0gr8PGEuiGib7LqENW5+Zq235qSkHceDehoyJ7QY07T3IuCrA7wP7T8ebcmgz1AarYA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2862,245 +2805,246 @@
       }
     },
     "node_modules/@umbraco-ui/uui-boolean-input": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.16.0.tgz",
-      "integrity": "sha512-IRU2z3GV+WzyjUvIMeErYeOE/0GyOpItsXxfmxsEENT/7qq4UMk28fIxY9IdDfI285WP0N3kezWkPBPlCKBcNQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.18.0.tgz",
+      "integrity": "sha512-Jbn2GqNIwoO1oDFyn4CHp3qxhjBSl6NOtr6YIrbx/7NMUOjfSh9i5roimSK1pfM0Ayu9FblTfzFQ1JHeDXx+iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-box": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.16.0.tgz",
-      "integrity": "sha512-/Wgnv2jr6wKG436WNjBdGq6x+aExiZhZgLPnzrTcaevy85MM5pJZWgY1+aI+pJclgU6WtRMii2+C8MZL2Qmh0w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.18.0.tgz",
+      "integrity": "sha512-qTSR8dKmF5WVSLgfRdVkRpu39ZplKAPd44770W00beO6LFcjuJB90FE12j43YcrHph5U8rZpMLP0ilfgDmeQ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-css": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-breadcrumbs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.16.0.tgz",
-      "integrity": "sha512-PuLcxG+3ZeSXKH3M0Kkh3eVYOEJPwLfg+6+b4UXxV/O9p0tUFbNPc8ciggL/1ZBXYXjsQnFTaOQWV4zGpnCnFQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.18.0.tgz",
+      "integrity": "sha512-U3jTCdNrck+OTIHjqe7X/IaxnALRBlrdNKGpAphCK9nYVoBH0K8Qobo7pl7RAtCx70i5Z5Yd0ulqo2l3K+gHLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-responsive-container": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-button": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.16.0.tgz",
-      "integrity": "sha512-0nTAx/GVOdGvlekkIxZp1nJs2E1DRzbdUnARl6RN5Oc40HowW9oO5oJvDIpoZcsWqkqWzFTQqVgE1z1PafKHZw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.18.0.tgz",
+      "integrity": "sha512-F2mfPByJOIgsHaXgX/2l73KgciDqwqI8OZwLC3ZWvA2aL2oGKbj1xTDBriR8zMjB5cGrFynH/VcXqx6SmAZ3XA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-button-copy-text": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.16.0.tgz",
-      "integrity": "sha512-CXjJzLbedqHtlza2zspSWNZCw5XhHV5QkPFzRI5Zd8FwFZop1/UgM2GQeSrMaWdfpznbWvfUqnvSYt9wYEubVg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.18.0.tgz",
+      "integrity": "sha512-/leCME/s5QpKxXqZwekzIS08f/FdymFjiAW4qFVn3e4D86ZDEA8QROfoaPNkXIZ1jLDFRjLMF6NO4SfMJ2C12A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-button": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-button-group": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.16.0.tgz",
-      "integrity": "sha512-ygici33P70SJqa2SSjdSVd8paSKqHwewKJMcyIF/IehDepnDP0ngSHWA23B/sEzJNJgq0Zngo9g3jlhZz6H6GA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.18.0.tgz",
+      "integrity": "sha512-65siyrZetA9WNcH7vFtH4JYPvwtffaEzAKiT8tvC9JJdRceRcNB2xpxHD5NimvqA6H2eu1XKgfCTKDPOp5nU8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-button-inline-create": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.16.0.tgz",
-      "integrity": "sha512-To9K/mYXLm4SGih3uA8/jbZd/ewWKVvYH6b26F5fvEDVT+X9fjJchKT7J/u0a4C7wghvVNT+os7H0rxS3yTXiQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.18.0.tgz",
+      "integrity": "sha512-S9+GY84pCigNX6rJa8o7e/GFiYm+jzUj0VvAG476qaVSghaO6ccw8Slp/zzLd+JQM1TNVohRv5BA8L2iRR818Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.16.0.tgz",
-      "integrity": "sha512-o/8vDLT03WnQsJKyD8r7PzxvhD3loRI7pL3tZU1BeSDcFAOZPPWIudQ/OwYeJnMI1iHkd2eTu0h22B/sXOfIIQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.18.0.tgz",
+      "integrity": "sha512-ca05RxgHuAyLUktiyqKDmXdp1a+Qns2o+cFo/QdAe2aRURnCA003NtNupp6qov7l6/MQHWMG+0FDGikhT5jfxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-checkbox": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-checkbox": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card-block-type": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.16.0.tgz",
-      "integrity": "sha512-Xpq/kB/ofSn067teaOyS4hEsEt/WUlrJ0opTFgkwHxsWg9rvMzUtg2nc2JGMoIqJ64/40Axcx0jmmchIDUcbsQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.18.0.tgz",
+      "integrity": "sha512-LZetD81cwtWpLD67smnQENZuzTNiFrp1VGbo6oHyrapQOnQij4L/c+GjqPpFk9qWIillJuvxovW+vO8p7djUWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-card": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card-content-node": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.16.0.tgz",
-      "integrity": "sha512-VPRDFrZSPLDGE3kAarW78dZHIFBhwXakyj7PM278tcXGdfSM7M9HsLXME6DhlleOYfSV07wHXm0UXKieqO7vgw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.18.0.tgz",
+      "integrity": "sha512-DwsHyeIL+4qmz5WN83i+xaU+adejcSRLZwUqv/eMa1s/OrPAv9WaDnWrbSM2s3Hg9Ne7gAD/q+r154ZH/JThig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-card": "1.16.0",
-        "@umbraco-ui/uui-icon": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card-media": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.16.0.tgz",
-      "integrity": "sha512-IHFCnXr4Bdpj/aUn+jpmlYx9L0FzeWTwt+cb29b4oP0cjIiVaJIrkOCSIl3SF8ncrKfMlTjlgBe0t0sP4mjeug==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.18.0.tgz",
+      "integrity": "sha512-l2XZftt7lwaT13zSB8fLugSDgR06zbOfh2bvsEU0t7D6kdc+JOFCgmAa064pPVqAge6SPC8EXfbfwtb+rmXOug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-card": "1.16.0",
-        "@umbraco-ui/uui-symbol-file": "1.16.0",
-        "@umbraco-ui/uui-symbol-folder": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0",
+        "@umbraco-ui/uui-symbol-file": "1.18.0",
+        "@umbraco-ui/uui-symbol-folder": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card-user": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.16.0.tgz",
-      "integrity": "sha512-Ne64+ssQrpP9zJvlJhH1Y5xlEDMW1lG17Orj6XH99iDtGdrnug9FjRE4vpNfAVRIb9P1pf7xNJtq2XqCJHvqOQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.18.0.tgz",
+      "integrity": "sha512-ZLea0QOaw0cc8OCkbBhLHa0ApAm7w76c9HGMQsHVvv8p0sW4+JJlx1iFEsRXocTaBgC+TZCdcSTX514SZmYecg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.16.0",
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-card": "1.16.0"
+        "@umbraco-ui/uui-avatar": "1.18.0",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-caret": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.16.0.tgz",
-      "integrity": "sha512-B3xNrwkQBwye9ydlrvnYfbJyiLqwQEbpldfaJnjLvlW9xVhOFps2NfeRyXcdsvruaIwjml7aB18GVYDCd/PSlw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.18.0.tgz",
+      "integrity": "sha512-XdKU5yv1nGN+e2A0d0DfUlQlM8V1blE5S+yB/M5/xWfiKXqw1XRKmZBf3fp5Fi8qA3jW9SyZOFSLNVeEM49zEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-checkbox": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.16.0.tgz",
-      "integrity": "sha512-4z8XrZ0InVArdHKO7L7uwAMwUwHyQKqSYShE74VHHWOibySciJ/zPx3hFO3eQ7EBL3Kj+4raun5Ah5jHUlDZwA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.18.0.tgz",
+      "integrity": "sha512-BqDEPCVBoTEsyJnVCTOsKMqcui/VdOGhQGpzhnlYoYIEeEPpyLjU9LHgnYQ4pTNSeV6tm9aSJUA+Kh+WAkrkjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-boolean-input": "1.16.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-boolean-input": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-color-area": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.16.0.tgz",
-      "integrity": "sha512-wiK9WNZWZ5yFd3ouTZOcoUSm+2iNZIFlGTaTScnG/DiLCBs6DUvdbSbVHueY1cGWbOx/R8N01kZBls1fk8kaHw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.18.0.tgz",
+      "integrity": "sha512-P4CiBXhxX6xFInaMTfTsjqyeqT8bR+IBoZQF3a8zkBdG9gmzVgzTzRQlahldn1UAQEtBsgkSWDZQ+f0S6Pshkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
+        "@umbraco-ui/uui-base": "1.18.0",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-picker": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.16.0.tgz",
-      "integrity": "sha512-IilZw7Qn+2QF80OXktnoY1RI45ggl8o+QyF5a6zjd2gl5BfwAVx/uFCnpDfjH6LKtRw9WvuPKHQyM0/mfi5I4g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.18.0.tgz",
+      "integrity": "sha512-pNaSMGtk7yA8BdE7oCuW/jKaqFAAaomnJpFM/mfHPU/Tp9mjrROm4bEXYdTauxOgXoRpYHyZEcjKYfTUOCJhwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-popover-container": "1.16.0",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-slider": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.16.0.tgz",
-      "integrity": "sha512-GDlAv+75efrOq9K/mZSKLwmc/ZG82hCaRMpWI4guKKvJhcukIcg7Bt/jQrDrtEGKCYvMJpNzbqZ41b+x23EQEg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.18.0.tgz",
+      "integrity": "sha512-JzljnkfOIzjrj66FWdb1ik+fl+sHUCvz2eWY+ymTfHQqviCzT+u9Xr2QZDDF3prZ2BhoiObHbLg5SbLDvs1Gjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-color-swatch": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.16.0.tgz",
-      "integrity": "sha512-I+0iEkIGXzoDfLUj0duUJsdf71FC1EBqNzAH/X5noiWc+RZiAAw5EvXm7rZO69oDNOQMwt/yMCBLJQp2kYOQTA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.18.0.tgz",
+      "integrity": "sha512-rEP01M6QmS9w0ObEXya15VZd1bY5VPkrXBzX7PQb/GgWkVzS+Uuows2I/jZD5TRUZMS7pmMU1Q7AVakeMJDEYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-swatches": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.16.0.tgz",
-      "integrity": "sha512-i58T2PRYzViBTo7OtJAGi5inVF8jxVYBmLL7nb3dpNjUFTZZufRKTr3AsVS7+pCGEogFmyNbcNztmmEMdU4ekA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.18.0.tgz",
+      "integrity": "sha512-XKDRzsrccVm47wDsoGwfIFxmb6oVltZkD1uWNvcQXCbYqSs1oyxWCI1vmSBa/OFNbK4br53q7vp/7cgNDZv8Mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-color-swatch": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-color-swatch": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-combobox": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.16.0.tgz",
-      "integrity": "sha512-zjeNG+7r5J4UgdeWh8Osktkjk/Uret5tu8mUtpp0Z6LIbxISUKEt9QlbjPPorxB3V0ENKUJ2c5KZZtpj7mLihQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.18.0.tgz",
+      "integrity": "sha512-AoUTrkgbx/GvgKw7sttVs3FxjRxuvpV6ffU2J/DeO1EFaxw1rHWZUgxKURQcBnPs3Jd0cDmjjloALyswcIgtTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-button": "1.16.0",
-        "@umbraco-ui/uui-combobox-list": "1.16.0",
-        "@umbraco-ui/uui-icon": "1.16.0",
-        "@umbraco-ui/uui-popover-container": "1.16.0",
-        "@umbraco-ui/uui-scroll-container": "1.16.0",
-        "@umbraco-ui/uui-symbol-expand": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-combobox-list": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
+        "@umbraco-ui/uui-scroll-container": "1.18.0",
+        "@umbraco-ui/uui-symbol-expand": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-combobox-list": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.16.0.tgz",
-      "integrity": "sha512-gNFheYUtzMvQudvzoRhDgJk9zziFTxSyu92aYzyoyhh7M098gJfqU+fo7Teqqiuyb0NEiZPThcNrUT9MD2LD3A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.18.0.tgz",
+      "integrity": "sha512-niLRnK8Yjx5uThBYPtOr4ptEYiMwg/QlgXofxtgb1TQw0sfw/S8Q5mBose9M9gVlbnvDzf3ejNJMeMsgeY2RBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-css": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.16.0.tgz",
-      "integrity": "sha512-uyr5zWOfqSH2z1He+i8vZVYZk8Bq4iKMXqCerKHuiNoCZOaW9Kg8n+mJXhQ3Kz5+r9RXUbJThMJO/6/8NFYvbQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.18.0.tgz",
+      "integrity": "sha512-ncKenHQX6ZX4bbF6ZKVZErLjY4JFh2FNJFrZBtHbiK1oU3p1Lrecgv7zczTLXjqn6FszEwkUcwafVewxwxAT0Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3109,603 +3053,618 @@
       }
     },
     "node_modules/@umbraco-ui/uui-dialog": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.16.0.tgz",
-      "integrity": "sha512-dq+daSQKAIdsP+2QhM6HmU9Nr5VVzbxwQEYLVvAcmYcw4K98TVpP6AyHu5dPDP9vl4EBBXUrrZuXFjU+Mh8/xQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.18.0.tgz",
+      "integrity": "sha512-0FqGYbkpT0KNSeB+xJwIHksTzE8VSItuobHUvpN/pg0QxXmZ/Hv5svIKAmw0baJPiho3w1UdsLQwRB43yXTqgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-css": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-dialog-layout": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.16.0.tgz",
-      "integrity": "sha512-iRpmlzp1PAUpF6Ol2EWubdABIgpJE6QmBzaQONm3Mmwe1wLxMGp5+o33wHU9WSTh8kDrH/U5mWtua6Xtyf5JFA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.18.0.tgz",
+      "integrity": "sha512-I9W5xDBmlkU1Qskj/4NRQk01ofFxd0i8pXUTkJGKt/N0YwQzG98Jpu7Xdi1YQ3uo2xZObPiNtbqIYGJN1Y7Iiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-file-dropzone": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.16.0.tgz",
-      "integrity": "sha512-B3Zy6jlyK68ntaC4idv7fzd9NVyc4VVjn68DgkvnHR76Mp8zmOgT0g7K7/WM33IPw/n/ZfBhM1KEb+ry3i9/bg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.18.0.tgz",
+      "integrity": "sha512-SJYZP6Cs2FcZYzlpBoI6B8srwT4bduQYBpOXYHeUP9gP7w3dD984StoxNLFssEdazgghLIb7OvQQ4yjUBSzi7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-file-preview": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.16.0.tgz",
-      "integrity": "sha512-A+jych/xEUOssZjqWtW04nD1GcVOHnonTlPdrDaFh9PhwQAL0PREBbHZnkLJBS4z+HKWhsXOUeQ9ju0YAtbRuQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.18.0.tgz",
+      "integrity": "sha512-7iyZ/uiC8SzojYP3lkyYE2gYJSAQ3J2G2/LOctUpgM3b7ghJt4WAs1Zj95C86uHPFP7gYmjkf+qyRR+5R2KO+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-symbol-file": "1.16.0",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.16.0",
-        "@umbraco-ui/uui-symbol-folder": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-symbol-file": "1.18.0",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.18.0",
+        "@umbraco-ui/uui-symbol-folder": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-form": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.16.0.tgz",
-      "integrity": "sha512-mZVeqQtKirPHCES6TcTywELJi3raBgSKRt2XKCmHMDzclK9P11qPuOve335Jd8WPISsqbbcw4mIAGQpww7TxIg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.18.0.tgz",
+      "integrity": "sha512-ZvkYdk3qL0wx4PTUnbtbsqY2Q3My6fN2aJHe89Il2Ptx/aY3gsjEshZ9GfJZjPWnEieRlbOwEu4LyhqPqBG4AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-form-layout-item": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.16.0.tgz",
-      "integrity": "sha512-g1xYut9TQzAK1w0fijWyV2PlXJnaMw3MYgytvsEu3XD93hPut4XvkifM8Ja6YxpkRcKQpRRLa4WHroQ6OQY6LQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.18.0.tgz",
+      "integrity": "sha512-1FLIB2lsWPMUFlF76hXG/Ws4NIBP2dzETjUMt12WVaFEvcM1vQGKqfj91RneZBDvfbscgNbIlZPvQ2R+p1iXww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-form-validation-message": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-form-validation-message": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-form-validation-message": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.16.0.tgz",
-      "integrity": "sha512-55+WAkF02Im+bG1Xl1AABA7KIGXr5CZTgHbr3MsVVHJMtHv+gQZ04h+0TkvDzKZDSg8ucCXJKyD44Y4gOyS2oA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.18.0.tgz",
+      "integrity": "sha512-eJzFrFVlrpu+80VqxX9Obcw4WQ5G1TNxgADjQ1uAAsAt8ovJ2sjMqWe0S1FJMpdFSgLeQj8PQLBlCNAZ3h//Cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-icon": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.16.0.tgz",
-      "integrity": "sha512-x7HX9OnKOTgjbFbSSZ9Pk0+Lf6yo8ggLe6XTnPClu3ByN2fl9/QqshI5lx4oz5Adr/ItSj3zqnNB2JbyM56TLA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.18.0.tgz",
+      "integrity": "sha512-t9xebF5fA1SSznf7inH2PRMHWpr8m9u1q4+prZVjMtWAtL5wDBsS2QZA6v2EG3Lv9T1cGhN5zbbmyLc5qYmYTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-icon-registry": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.16.0.tgz",
-      "integrity": "sha512-o4l2bEYKdBcxAlSwEPO+cfnNvkGuGcZRyca026xvIz+nufbc/BBzskzS1UWIIjkFPu64rHEfxP/3KbSld64HYA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.18.0.tgz",
+      "integrity": "sha512-xv7bhzCFZfuRmDhMrHww3Ucu2osKJnZPyYmPkBKraS75X4K+tD2012QZxtUI9Dq+WRLTZ6htpOX75JL2FE3PKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-icon": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-icon-registry-essential": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.16.0.tgz",
-      "integrity": "sha512-HI4cnYhWpPtWFFgfEltjV6PPhOd3NQ58BhqfbCpRbwmHZUZ0OBzGRl4QgsPNKuhQqmcXene+Twfy8eoRk1/5nQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.18.0.tgz",
+      "integrity": "sha512-0tOFOZtjpzkbpfZsTczRV2tWFXxZJb+GnA77WI/dFoJEXVfXWMeHiwQPbN/znhE3TSqrRPt2LN3B9PTp5lWZNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-icon-registry": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon-registry": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-input": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.16.0.tgz",
-      "integrity": "sha512-2Mp15ObjyAuRD3bOTs/zuUHqaaMiuDhmGsjeK8ViOrlSMnz/bVUme5scN1OMkNIryVHkENshC4NK7x6++X0/qw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.18.0.tgz",
+      "integrity": "sha512-KBXxmRNO9K+I7iNrUkl6x3rz20M+Dnn7bf2kWNqDrQ6xWxaSePX3bfJIBy5DVOcV2CgqnT4UcdrAf7ByPU/3Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-input-file": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.16.0.tgz",
-      "integrity": "sha512-AxepSUJe0LmY4QmBA9UlzhZBBrVF+z88fFUWIH15PICFX0jfsPNIeiwQKlv7cN5pEInUh6qCRN64z8icf8fcdw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.18.0.tgz",
+      "integrity": "sha512-f6q6sebzA3/1V6mcTG9dq8meE4R5c0ObGbzQBPyDH6oD3bl6z2insoDrLVifPPeXpu+jxPIzcFOLzNwczP7Tmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.16.0",
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-button": "1.16.0",
-        "@umbraco-ui/uui-file-dropzone": "1.16.0",
-        "@umbraco-ui/uui-icon": "1.16.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.16.0"
+        "@umbraco-ui/uui-action-bar": "1.18.0",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-file-dropzone": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-input-lock": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.16.0.tgz",
-      "integrity": "sha512-FTLj/2s+VImEtKe1GPSkAC2pmTabz5cGzvaFB/7xrJj/1evVxXGu8qQyyL96WoDe+RAmBNYfrnGx7OUSVhEyRw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.18.0.tgz",
+      "integrity": "sha512-thSsryOwf5zDgQJbgijtum1WRjfXnd+lTZWnmh2Ewh97iZVeCXw8t/3ScmaQdgMvnNv7D7WKRAA3nK1AerWlew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-button": "1.16.0",
-        "@umbraco-ui/uui-icon": "1.16.0",
-        "@umbraco-ui/uui-input": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-input": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-input-password": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.16.0.tgz",
-      "integrity": "sha512-0gg8nAVHsMYlQscG76PN4L8ha3CpW15crlzgj4TMaW24OIgZ0khV18ZImJ5n9wv/zrq8LsrwJTyZ5/a/soaKyQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.18.0.tgz",
+      "integrity": "sha512-BbbB7TYiX8xCMD+/ZVJJlS1tCzkiJUK7bobRtcKC3Alrv5ogKSqAyfsXDqqNyAKsGhR+HCzShEVzpMUJjD9Kyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
-        "@umbraco-ui/uui-input": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0",
+        "@umbraco-ui/uui-input": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-keyboard-shortcut": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.16.0.tgz",
-      "integrity": "sha512-z9wlhONxtwkUCkPEKqt/vSH1qOTwHCIM2Cj/DQ21+bfWcywUR7cAp0vRveapymDn4eHSuRra5lrG7xgLYsYuVg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.18.0.tgz",
+      "integrity": "sha512-PA9BPA7e14HpsjWNAnzNCHJ8i3Ex56Gv6ERzlTVGXISS8cv7HvrJAPsYVEywt6jci2l9jDvi35MdAcL14WrUfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-label": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.16.0.tgz",
-      "integrity": "sha512-1vQAKUR+frDEth8AMLS5KKpVK2LHD61lWUG95yMypF5C2+YBmzXb70QEakOubTMsmLnYcU3hfORfA5Wp9cYPnw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.18.0.tgz",
+      "integrity": "sha512-GfPD7YsoaUs3UU9f8+OxYVxTKId/xWXG6o8KaTK8XfVvICnxWaQIqcbaHyRR773+5H8kvfxBr67ahPcGSoo2JQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-loader": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.16.0.tgz",
-      "integrity": "sha512-wcFUljPcrAR6YYuj5XLmtMpZBvzTBcakr9p+vISOoC3ta8UlE+OOLiQn+XYzTuV/ZbM77EHh5EEyiO5L45fQew==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.18.0.tgz",
+      "integrity": "sha512-BQwK7+Ldv5V2IpBIeFaJ426zruKYc9X/+IE3YCTiIAn3lrLx03IUlLQwxzI7R3sU0SHR0/HQjK/2KKYA//NOwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-loader-bar": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.16.0.tgz",
-      "integrity": "sha512-xh6RCS60WPWPzf0dAA+lTTt0rF8hksQsYBLwITBsR/5k3qswhT9Ctu/2LvqUXoLPyEFTecA4fyqZK+NzhjZrdQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.18.0.tgz",
+      "integrity": "sha512-UY3cE0d9MkPWGxIpuv0zbdgsEqUi9RyT5V1yWXi5GPBGJ/fU6/Hu8oHBkrAPC088vGLu9e52hLs5e0oaL1LYSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-loader-circle": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.16.0.tgz",
-      "integrity": "sha512-jawUHoiUwwZkp5YOLFlF00WvZ5yPowfbi22TufSyfls5hMajJM/p21IrCTStrc4ZimqyheaaYe/AqdGLDimfSQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.18.0.tgz",
+      "integrity": "sha512-HN7TPxDplGA1WD2bnuZggblBFsQXSEmXtHkmTOidLzwggZIkZyDBoi0hbGD2PN0fJvLsLV+1aSxDXqmRVRhWXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-menu-item": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.16.0.tgz",
-      "integrity": "sha512-tyyuehJSj1BU/EEsQ1LHN8eg+gcAKCzqGMwwpepEtKZDd7p1/Ioq1KEn2e20UOihXab5rFv5UNEWSeyEYRqL4Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.18.0.tgz",
+      "integrity": "sha512-yT4DwOxPls0Rh549PJFdwgI46Hen9oPBVF6c6iGOTBgEbzsSgpoUWi1UaCtZe4WxDQ1+1SsF+JW//W+ZKJAmzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-loader-bar": "1.16.0",
-        "@umbraco-ui/uui-symbol-expand": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-loader-bar": "1.18.0",
+        "@umbraco-ui/uui-symbol-expand": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-modal": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.16.0.tgz",
-      "integrity": "sha512-hqlXHjlGxEWEeX5c7W0xNlH25xDbb8vdgBIfYGUkBfrYrgO3j+AJ/B7OvmgWJogFTOHRRaPUvKDi8DkDnDH4zw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.18.0.tgz",
+      "integrity": "sha512-7x6yhHTYtfvZVZRc8hhgBkiwRq5SlXoJ/jdQ69xlL8iLEjoFTA3ZqBkcKLQHpWXVMYAkAWGiJhDtQ2WCmED5Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-pagination": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.16.0.tgz",
-      "integrity": "sha512-bZQl5BwiYHSQqc0bjajQbu8ZX+z4qe56t6PiT6s+VUj6huXOOrT72hpY2u+ZE22sAWPaIu42Kg9ulxNV2pulRw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.18.0.tgz",
+      "integrity": "sha512-7jlFROK1Kuu/waZ+mWd6+ks/x5xxf+NiwT6J4cQTnYJUqQKLmZ9ZesTndtU8fHBKER+H6bT/m4Rb7RkMIQ7Keg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-button": "1.16.0",
-        "@umbraco-ui/uui-button-group": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-button-group": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-popover": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.16.0.tgz",
-      "integrity": "sha512-ZtHPdupRjxwuSHmY5EiiGtZMBi5UsAyHOucn5SxMgdyHT7bRxrV1ebCblDu4eikXg/xx1nTDSFmmW4rXLftULg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.18.0.tgz",
+      "integrity": "sha512-FXIuz745J9GAHKZ+GQ8UODwxmxe6FHfWb15Y4JMTLg+OzIiCe1az1Y2rX49/iSULvmB2x8ci6w+EyaIZtiE7Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-popover-container": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.16.0.tgz",
-      "integrity": "sha512-3N8M4hPQFcthVfqfhdCMX9B4q+0sG2zizoQf2SvDoLp3GAqND2zw2cwYClMy8HJh3XH9JINljz3PliyKMXVaXw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.18.0.tgz",
+      "integrity": "sha512-gyQKjGp/m2WGBZgX99Q5GJBJ4ZGYl9vQDltVUzuIS8mlD8GJYukSWa3ALs/dRrN3nuT4f+rZWOt1NI4ZBR2tJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-scroll-container": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-progress-bar": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.16.0.tgz",
-      "integrity": "sha512-GE/ZW5Rq82LgVbArppIG8Zkd6QFmCTGEV4Iq5V4KPOl5iSVu2yuYJCDD77aR1LgclSjk1YiJ1/oge94RXqAtOA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.18.0.tgz",
+      "integrity": "sha512-zGkokXSwvZQvhEcdhf6mHTpeqqWZ4lFXmrLifih0VFzzBHgDHS4wuE3COQLNbOkk2r77Ute6/QBf9dph4GOaTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-radio": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.16.0.tgz",
-      "integrity": "sha512-r3JmVGeGzCzUPEKdOzxunsoRO2q7zGoI5eUtrSXdLSFiR2klW+hti/fjvqvruqzRZRjB0oumbJfMU4IxHcZblw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.18.0.tgz",
+      "integrity": "sha512-Sy9e6/sA2uTN9EVPLQv5BBzQJXHGSudCr2nZ5MbhcI30mkip+pSEccv9Q32zoSJU2FG5WafQbZZnxl2kmhzuFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-range-slider": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.16.0.tgz",
-      "integrity": "sha512-9qx3Qj8kmIyHRbcVNexWTs4eGjsxs9FkjP7czpC1P0CPJFIt8LzeB6gBwSS/nJGuIo06RQ42qOc8FOza2tN+jA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.18.0.tgz",
+      "integrity": "sha512-d+nPhZfhMmUVHzPqJ8RzSFLaxUN2HQSNr1Q+yuUGhrJKCPxN7aHVPwHKDu+baR1tPI14vqiWpucZ2tIGMNcaoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.16.0.tgz",
-      "integrity": "sha512-+ptIzEx8a3Oy4XL6TFibR5Q5lWDpjCSPCN2DgIitBj9C0R8zWbBo8sxj2iLGP4RsBiHeTUbDiJlSY1seo2E+Ew==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.18.0.tgz",
+      "integrity": "sha512-JBH0YwQMPT49F5C98xl5fLhJsbEDKxIwf4KBltov8enO53vO9wP5nKOeTIHgJwRKpC4unxwIDws/8rKpwiXryA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-list": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.16.0.tgz",
-      "integrity": "sha512-MRxTX8CDvquBkkEGfpPsX5ttnsPGJ+Kb1KfR+arueXazQ9XfqyoFCAWWXfOxGL7A5txGTMnKEfj59dyLeCec5Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.18.0.tgz",
+      "integrity": "sha512-ZJwwcNCaNqQLa5wkYcSCw1EElJq9cVRe4F30gbCTlax4rXqR++Sx1XrKyA2+ib2Bt9N+6p1IQ0pFmyyG57uDqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.16.0.tgz",
-      "integrity": "sha512-4IO02sBoJLlErxXPeFBXTtOZzQeFbCf0flpHCjMZ+vWKZ6GarlUMSvbXjuzh5SBEveVxWYhjd7Z7lP+g2pOHGw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.18.0.tgz",
+      "integrity": "sha512-3WkGnRdLUQxZFtKGb/5rmvKBbK1Q4G9qZm4m1SpXB7qDzXelrR92SNjmr0My1nMk2JF29/ZFLihep9798H8Peg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-icon": "1.16.0",
-        "@umbraco-ui/uui-ref": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-ref": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-data-type": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.16.0.tgz",
-      "integrity": "sha512-0yRbSOoKl5gSAnRIEXTdFYlrt4NSvuLx1+TuQyeE/CV8lfObGqM1+y+ueX0AgPuNTXAf7j5rPIRLsVJHfCs2MA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.18.0.tgz",
+      "integrity": "sha512-jV9uWHwgUzCJun1UPAs46zS6VdJ1DrmqVSf0EfIQsGmHGiTlWP9FWfmeRe+hQ2XmqhgApo786X3oOrzChCO/jQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-ref-node": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-document-type": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.16.0.tgz",
-      "integrity": "sha512-ORBBH6GRq5VFTNZd++f7dXCLJdgEGhtd1rcdbxjqtYnJrKeJ0dBNhJkF3kLoSQ1MiOG1SHOckGUZr5nLMUhc/w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.18.0.tgz",
+      "integrity": "sha512-FfPc4E0DXhEv6EBUBWEhwMNfGK5Oe8GjEBJ+vyj5FjaLlsmmj6bG2i2NERHyb6mwV/BXpmU8Eji4giVsJeV88g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-ref-node": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-form": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.16.0.tgz",
-      "integrity": "sha512-Z3m2toN+LcZOXVe/3q6d9kyPyWXR9l8CJSk1NkEn/ojMYrRzmo5AW92xWw/twHV8bRsEBDSeKxSKMVGnJVyUHg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.18.0.tgz",
+      "integrity": "sha512-7X6VwMtvqwX9BOM3JysppnrbY9EsNzJyb2HY+9+BFANko8wf7heM9xOi5wv4H7cvi7xfKGZL2Vlt5UAvo1cc6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-ref-node": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-member": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.16.0.tgz",
-      "integrity": "sha512-v9m/e5krM1IPV1gI/9dqVKgGYthyWXDlq9lCdiigpTfzv7xkCF+LPEmVksDZaKD498gGYtbYJReCXUxCwjxGTA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.18.0.tgz",
+      "integrity": "sha512-+NRJLZz9avT7ibcybil06gweudgulwKVSWIhQMzbWLI3NaronRvQ2R5uoag+yC+9oe4YZKqgzK9VgQkzogjXnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-ref-node": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-package": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.16.0.tgz",
-      "integrity": "sha512-6z/oa4qX+L746nEet0EDx88roSTcfjnzQj5fH2ebW4WJ6Arh/b+QmPOE3UEn2QiqjJLovkIhNcwf0m9PM7rSSw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.18.0.tgz",
+      "integrity": "sha512-KX+FNt8SNEmVgHApZ2mweLSU6w7bXiUY7ktH5ScO4x24G4fwZW60i8HZpXGzCq2xshxcYKaiwfqFgTN3cHLOWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-ref-node": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-user": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.16.0.tgz",
-      "integrity": "sha512-TdYTh+1pZfOFD9dKBtti1oDF1Pk5Bp3PyNKf1JLtcPm8uD/UPDxRkIYV7It04E6P7VWusdRabdlv/q9PRimA5g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.18.0.tgz",
+      "integrity": "sha512-mgVPiedvhJFJLqT2LmmGLyTOYqopXO/5z65mn3AiNfMv/40dEj9gcnAhiw8pOn/Zhj/3kl3UI29rWXeZjCqGJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-ref-node": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
+      }
+    },
+    "node_modules/@umbraco-ui/uui-responsive-container": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.18.0.tgz",
+      "integrity": "sha512-G+V62k4iR9/C5Qeme6dfIWHtp3RH8R2Orf47A0B5EP5aYM9409/jDvE7u/1iWzBMPXYvGImLswatE7P73LRpJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-button-group": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
+        "@umbraco-ui/uui-symbol-more": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-scroll-container": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.16.0.tgz",
-      "integrity": "sha512-+ArdQO09sGB1t24rzi+rk3YsZZayZRr5aKny53qAKkklJg0IDCJ+Vme9DvuSk0HBEzCe0YF313lv5mYjxFwCzQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.18.0.tgz",
+      "integrity": "sha512-G3r6WMo6KvubCgaFgEV62Qgfu7s9BSXA3nfN9GPoXIwQgMulba5RK2LsVAv+z2TmmlmGzIFlHhK5ykyempNiFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-select": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.16.0.tgz",
-      "integrity": "sha512-/tXty/HSqTAwnqsmLIsDc8LsE7XW0pZaCu+B/Ov3FjYQSb312AqXBwP7Z59gAbh2M0XvI3qxcA/sLcFndqN1oA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.18.0.tgz",
+      "integrity": "sha512-17jq8QNCbefC9yy4iP5Br0JFEb1RKME+QFW+c2ndWP8cQC5/EB/a4V3oEVJ+pK9M/eb4ljkdBWqexO3jQYLaHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-slider": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.16.0.tgz",
-      "integrity": "sha512-zWXe+SOzXbhO2tN+DnVXbefEWICZ+FHCR1EGldZdab3hQO53M4HOKqTBd1akE6iFli7FN4BOnELGjnMnupaqvw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.18.0.tgz",
+      "integrity": "sha512-OTx7kyHO/HspBARTbtMLdsVY7KqSP+cKWDJvuJVKey43qTUCDSGkxHxRe7yoThUceuwEDZUtGEvTaalkUrRAtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-expand": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.16.0.tgz",
-      "integrity": "sha512-w9i+deCNhZ3TzwgMx2glGbpyvXQHyP0kCmuazXi4cYGFtEXM48d1OScm/PrGs04ICNuqEIwY/IZ+PGfRSI27lA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.18.0.tgz",
+      "integrity": "sha512-fr8ZxC0Ti5oM1mKmQQx29FCAZ3LS8Cql/PxqO7vqdZneC8i/K8vGmCssgTRy6a+O+Lyqoc6V8KxZEX6ir86gHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.16.0.tgz",
-      "integrity": "sha512-8iyZCjVAFvKrz1m0RTPiZmbXYLyb0Gs2blgg/uPyBzpNvptnXgx29UVTzITu2xvqVvwvureFNcxqeYL5WsfCiA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.18.0.tgz",
+      "integrity": "sha512-C7ADFl8P9M1y2v0ypZrozju5na6IGEdwJ/563M0umdDRA4pyzRgBC/c/EStSbQvTAKdO3ZXIuH+RZKpkIWL+2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file-dropzone": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.16.0.tgz",
-      "integrity": "sha512-d9VJQTEBKwTHrvgPAXLgG4m3quDbxg1EhJhE03cxZr/yrZ81I2TD3wd4Pt9uxL1kvpZ95mP2vDfbedUfm/0fww==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.18.0.tgz",
+      "integrity": "sha512-42B+nEBTsW/KPLKaKW5P5uwZXaxOvtz6NrdFuzjRVxWReyMRfpSWRzaiZrJsEPCq2DTSkPTX8TxdDMlr1Gd9Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file-thumbnail": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.16.0.tgz",
-      "integrity": "sha512-PMm3lTtIAwyE+6Erz2xiamKPuHhqazk2aWHgqC9fzD/0ROlWQMYEP3M99onp8/YCIprzfvXPuH6ofs6kq9bY7Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.18.0.tgz",
+      "integrity": "sha512-7SllU9o6NVkvr5wagpXdkxSjqm4P76TWSPg0ZGas6ODTOyTPXBaPz95W6cWUVbF6k6Z6WUmlIcmS5x23JUncmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-folder": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.16.0.tgz",
-      "integrity": "sha512-vATvt+AcfP9pZxh99DKaq/wrD60EN4nvdtZ/BpHH6MOhX32T8LEboh57XisHmGamUSGbm2jQhASJTt+7cvjI/w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.18.0.tgz",
+      "integrity": "sha512-6IYJRO3JtGgfc+CwPvUmcIyY25m4rEVAUM7fqMQrk/WT+WGQSOqcXEGPlm2bVLx+0bKIUqfD/lohWhlYmUQZVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-lock": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.16.0.tgz",
-      "integrity": "sha512-mAFnPdUzlddfdLMTkBetCTnShV3QTWMpjqaG5fCaauizWmReye/rCwDur51URL+VkWMIWp29JvfYIIm8Yk+ZGg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.18.0.tgz",
+      "integrity": "sha512-uRmtMdCc2CLdOPIgHEu9Gbl6od8QVv32vr0969wS2MgeQeGo56Q1X6QyQoiUbO4j0/wREYWs983mPxXyhphbhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-more": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.16.0.tgz",
-      "integrity": "sha512-WBd/6SNLVP04WU0Em8Uc9/GXsKYpYdHzlEjh7w5oU1TfbDEiNq1lXkOlpuvL79wJtd/2fTKfqui02+i79KU7ig==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.18.0.tgz",
+      "integrity": "sha512-PZd3Z66KdfTc9VJJku4FtSCEXyPnlE+/tU81HJsmOkx45q0U9kcpnaOFNIswC7vjftCO3F5GrAGlbDf542wkRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-sort": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.16.0.tgz",
-      "integrity": "sha512-hBhvUmkPc5WgFcjKDm6jtQq2USCO+ysveJRI1oJReiZkyj06IjU5mYddUL/sOG4L7Ud6OFqVbY002Uw+j9QpYQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.18.0.tgz",
+      "integrity": "sha512-xcYbSLLaM3+zEqNxaJDSi3HdYpIQmJO97gKv/nXZZKpOwvPSKOWdiNeWEqtfPxMEmhLbWrzrHgw0FTQjbYOkkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-table": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.16.0.tgz",
-      "integrity": "sha512-cVq84cwbgOvjoTn+5L4eboXPGkYdcIkWm/oU8GxbR1OdUtgPtqnPwB51Ial6ylyIHqvYbCDmDMzrjjnrB/qfJw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.18.0.tgz",
+      "integrity": "sha512-3uUV2OWDQfQj0Ui/muO6O0iBzNW0I0jxa1Z5Xj4NjqNfkcsF7TXdKLypMPB3NrgBvyG5IpCRFurQIVdd+F22ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-tabs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.16.0.tgz",
-      "integrity": "sha512-FBToNg7zgB9paPQPbpnuC66KAMz3iR/F+tmLhjWnwGSit7ubFspPqgrReSjVS9zdd+zbi7wTJOcmKnHmoyP1bw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.18.0.tgz",
+      "integrity": "sha512-q2LymkAcN1PLUMu+fxp7XHxhSug5EU3c0QC+Jtbdjy8b1BWl+EULXhAvNy9zYN8BtRJ85PPIXptU8Ly8vHwxsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-button": "1.16.0",
-        "@umbraco-ui/uui-popover-container": "1.16.0",
-        "@umbraco-ui/uui-symbol-more": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
+        "@umbraco-ui/uui-symbol-more": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-tag": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.16.0.tgz",
-      "integrity": "sha512-u6pBhOEvXYvUNTxNO1Ftcnflii1CmeuvNAXxuIj8TMmTXGXWmap0W5cGmzlEbbLAMGLv56AJXdz3rKDrWNyTvg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.18.0.tgz",
+      "integrity": "sha512-fazWCxOotzDfuYKde/2CpvJrEVt0vgXuniw1NAs94Gc+hJ6fRQcNEddCzSf33QtZVVH3ov3EqHoKKOj5dourkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-textarea": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.16.0.tgz",
-      "integrity": "sha512-xTO4i/m4Q7wEeaxmV1bxT5e1bnLRJ1CoG+awe2FKGq6xw2ZHgksSrm6j3Ddbm5WzV019hIeVl22bnVQ5gOwrww==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.18.0.tgz",
+      "integrity": "sha512-B7iVItNSY3PJsui8HUBugCazFdFwNfuiLml+jqS2/leM+VUx/svwK1Z/Xb46qCo6DVN801lUy9KkCFJq/baCSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.16.0.tgz",
-      "integrity": "sha512-ziOJ4uyQpIVCBym2RlZFJOuOb2feNr1sP0RxUjhXToREJdG2MH2bgYyy76K0OCZ7a+JKCsHdaBH4XquXIH93VA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.18.0.tgz",
+      "integrity": "sha512-2tnhjRPPbH4OfAGb6NMyuIxe9AYeKON0Op2v58Ydo2Y9LUSYnf/tccRKxX72p5a/FYAwLGZmqhBA62M2xYipEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-button": "1.16.0",
-        "@umbraco-ui/uui-css": "1.16.0",
-        "@umbraco-ui/uui-icon": "1.16.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification-container": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.16.0.tgz",
-      "integrity": "sha512-8HwiYkOA8Rsxpp2ZGsDTq16odV7Ja7xAAp/0BcdosdQYn6L4KUbSimulGaP/Q1KATUCFT7QflQiv0gnwuPpngQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.18.0.tgz",
+      "integrity": "sha512-1vdfySxVNf0ZIlpUmctT3vwjng1Vxnb3NxDeDZP76xqhIxwnoq7/Ku7J+T871N+zNB9UZgFziPOpbrpOF1g0Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-toast-notification": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-toast-notification": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification-layout": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.16.0.tgz",
-      "integrity": "sha512-OTrTAGUPe8EQRuCWJD8GsCw8MfNJuXx50NLZLDDZKzw3TlDiWMxUD0c4l6zOMy4ih7n7D5sMekHqonW5x6lVuA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.18.0.tgz",
+      "integrity": "sha512-jBVbb1whgkm5FqPGhPmshYRpl2QNJz/UlUQTJxggh/OeOvWdPscowgZ2115zxTuBDr7pAL3xZNCyZsqHZtd0Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-css": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-toggle": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.16.0.tgz",
-      "integrity": "sha512-opFdwN0LlH6l1xlzEv+e9tvLgySXRr4Ug5LBlzNRJKC/WhinUSq/okerIVyUJgk4oKdZV/y7T7u/07LiekCTAA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.18.0.tgz",
+      "integrity": "sha512-lWNGJbterJv4k489zl8PgEaCulBbiXYAwEUPLYr33jMAsPuxcYVbd6Rf9HZLZRw8O5153nP6RS2tN73VhGku6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0",
-        "@umbraco-ui/uui-boolean-input": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-boolean-input": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-visually-hidden": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.16.0.tgz",
-      "integrity": "sha512-fqcv9gZUey2FkE2IRWuDgpk+D5XCdC1gnmQ4bIlAs03cMhl2BWP7U04Zo1u78jcWCbjxfnp60rfE6h11ukd5sg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.18.0.tgz",
+      "integrity": "sha512-DLgnQkF5dWxH2hF+svjomESD+JS9/IwX6ikHgVIKF/7S/LMoeNwgvNaszUEewUzOpnY82Nl1jPl3xji3ZmLKww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.16.0"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@warrenbuckley/audio-visualizer": {
@@ -3803,19 +3762,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/dev-server-core/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@web/dev-server-esbuild": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@web/dev-server-esbuild/-/dev-server-esbuild-1.0.5.tgz",
@@ -3851,78 +3797,12 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/dev-server-rollup/node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@web/dev-server-rollup/node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@web/dev-server-rollup/node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@web/dev-server/node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@web/dev-server/node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@web/dev-server/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -4069,35 +3949,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@web/test-runner-core/node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@web/test-runner-core/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@web/test-runner-core/node_modules/open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -4116,29 +3967,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@web/test-runner-core/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@web/test-runner-core/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@web/test-runner-coverage-v8": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.8.0.tgz",
@@ -4154,19 +3982,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@web/test-runner-coverage-v8/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@web/test-runner-mocha": {
@@ -4197,29 +4012,14 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/test-runner-playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/@web/test-runner-playwright/node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4232,9 +4032,9 @@
       }
     },
     "node_modules/@web/test-runner-playwright/node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4252,16 +4052,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@web/test-runner/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/abort-controller": {
@@ -4356,7 +4146,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-back": {
       "version": "3.1.0",
@@ -4409,9 +4200,9 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -4419,9 +4210,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -4434,9 +4225,9 @@
       }
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -4449,9 +4240,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
-      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4474,9 +4265,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz",
-      "integrity": "sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4484,9 +4275,9 @@
       }
     },
     "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4494,9 +4285,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.11.0.tgz",
-      "integrity": "sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4521,9 +4312,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
-      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4531,9 +4322,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4767,35 +4558,6 @@
         "node": ">=12.13.0"
       }
     },
-    "node_modules/chrome-launcher/node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/chrome-launcher/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chromium-bidi": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
@@ -5014,9 +4776,9 @@
       }
     },
     "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5088,13 +4850,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -5118,6 +4873,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -5132,6 +4888,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -5179,9 +4936,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.3.0.tgz",
-      "integrity": "sha512-Qq68+VkJlc8tjnPV1i7HtbIn7ohmjZa88qUvHMIK0ZKUXMCuV45cT7cEXALPUmeXCe0q1DWQkQTemHVaLIFSrg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5196,9 +4953,9 @@
       }
     },
     "node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5235,9 +4992,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5312,17 +5069,17 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1581282",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
-      "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -5344,9 +5101,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
+      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -5355,9 +5112,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -5424,25 +5181,15 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/errorstacks": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.4.1.tgz",
-      "integrity": "sha512-jE4i0SMYevwu/xxAuzhly/KTwtj0xDhbzB6m1xPImxTkw8wcCbgarOQPfCVMi5JKVyW7in29pNJCCJrry3Ynnw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.4.2.tgz",
+      "integrity": "sha512-aQAkABfX+AsCxWtvh1KGIDkTiYyABsTtZkBb8cd9FWxNnEdrcFEsTxUfi9sc0Jc1mgHC2kW3UtJVadqSuMm/uQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -5472,9 +5219,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5485,9 +5232,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5498,32 +5245,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -5576,6 +5323,17 @@
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/esprima": {
@@ -5749,6 +5507,33 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5769,24 +5554,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -5802,6 +5569,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -5851,6 +5619,7 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -5869,9 +5638,9 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6056,9 +5825,9 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6085,6 +5854,16 @@
       },
       "optionalDependencies": {
         "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-flag": {
@@ -6127,9 +5906,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6140,9 +5919,20 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/headers-polyfill/node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6292,9 +6082,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6322,13 +6112,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6338,16 +6128,16 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6425,6 +6215,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-ip": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
@@ -6495,19 +6301,16 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-inside-container": "^1.0.0"
+        "is-docker": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/isbinaryfile": {
@@ -6527,7 +6330,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6569,9 +6373,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6586,10 +6390,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7005,27 +6819,17 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/linkifyjs": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lit": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
-      "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -7035,29 +6839,29 @@
       }
     },
     "node_modules/lit-element": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.1.tgz",
-      "integrity": "sha512-WGAWRGzirAgyphK2urmYOV72tlvnxw7YfyLDgQ+OZnM9vQQBQnumQ7jUJe6unEzwGU3ahFOjuz1iz1jjrpCPuw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
         "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.1.tgz",
-      "integrity": "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7124,28 +6928,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
     "node_modules/marked": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
-      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7172,13 +6958,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -7219,19 +6998,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -7298,22 +7064,25 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
-      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.1.7",
+        "dompurify": "3.2.7",
         "marked": "14.0.0"
       }
     },
     "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/monaco-editor/node_modules/marked": {
       "version": "14.0.0",
@@ -7336,29 +7105,29 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.12.14",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.14.tgz",
-      "integrity": "sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ==",
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.41.2",
-        "@open-draft/deferred-promise": "^2.2.0",
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
         "@types/statuses": "^2.0.6",
-        "cookie": "^1.0.2",
-        "graphql": "^16.12.0",
-        "headers-polyfill": "^4.0.2",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
         "is-node-process": "^1.2.0",
         "outvariant": "^1.4.3",
         "path-to-regexp": "^6.3.0",
         "picocolors": "^1.1.1",
-        "rettime": "^0.10.1",
+        "rettime": "^0.11.11",
         "statuses": "^2.0.2",
         "strict-event-emitter": "^0.5.1",
-        "tough-cookie": "^6.0.0",
-        "type-fest": "^5.2.0",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
         "until-async": "^3.0.2",
         "yargs": "^17.7.2"
       },
@@ -7404,9 +7173,9 @@
       }
     },
     "node_modules/msw/node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -7420,13 +7189,13 @@
       }
     },
     "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nanocolors": {
@@ -7437,9 +7206,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -7473,9 +7242,9 @@
       "license": "MIT"
     },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7486,6 +7255,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
       "funding": [
         {
@@ -7497,6 +7267,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -7506,6 +7277,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -7540,24 +7312,29 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
-      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.1.1"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -7638,6 +7415,22 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7762,6 +7555,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7805,9 +7599,9 @@
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
-      "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -7819,38 +7613,38 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.0-alpha-1771104257000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0-alpha-1771104257000.tgz",
-      "integrity": "sha512-6SCMMMJaDRsSqiKVLmb2nhtLES7iTYawTWWrQK6UdIGNzXi8lka4sLKRec3L4DnTWwddAvCuRn8035dhNiHzbg==",
+      "version": "1.61.0-alpha-1781023400000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1781023400000.tgz",
+      "integrity": "sha512-8TRUG3IvwaAhuVm6k3C5vB7CwC5Fxq76DCCxOgPr6r1dpTedDwxlmdOBUkSZ0zxfxP14jcuPxi86/Trq4eA03w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.0-alpha-1771104257000"
+        "playwright-core": "1.61.0-alpha-1781023400000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7863,9 +7657,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.0-alpha-1771104257000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0-alpha-1771104257000.tgz",
-      "integrity": "sha512-YiXup3pnpQUCBMSIW5zx8CErwRx4K6O5Kojkw2BzJui8MazoMUDU6E3xGsb1kzFviEAE09LFQ+y1a0RhIJQ5SA==",
+      "version": "1.61.0-alpha-1781023400000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1781023400000.tgz",
+      "integrity": "sha512-UdtUd9qnCO0zvb8p3OvOZpelY6mA40mTb3NmWGuMtrD+hqqWuorWCPlSGwj7jw/LEB9AxvYLHTL1CJi2flvksg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7873,21 +7667,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portfinder": {
@@ -7905,9 +7684,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -7925,7 +7704,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7944,23 +7723,13 @@
       }
     },
     "node_modules/prosemirror-changeset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.3.1.tgz",
-      "integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/prosemirror-collab": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
       }
     },
     "node_modules/prosemirror-commands": {
@@ -7988,9 +7757,9 @@
       }
     },
     "node_modules/prosemirror-gapcursor": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.0.tgz",
-      "integrity": "sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8035,50 +7804,14 @@
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
-      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.25.0"
-      }
-    },
-    "node_modules/prosemirror-menu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.5.tgz",
-      "integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crelt": "^1.0.0",
-        "prosemirror-commands": "^1.0.0",
-        "prosemirror-history": "^1.0.0",
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-model": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "version": "1.25.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.8.tgz",
+      "integrity": "sha512-BswA4BLSFEiORV6Vjj/yZBXDbos1zTEnhyeSSgT8psGFhstQS7UJ8/WOLiDos9Byaee27+tml0/DuMNxYR84zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -8099,7 +7832,6 @@
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -8107,39 +7839,23 @@
       }
     },
     "node_modules/prosemirror-tables": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.1.tgz",
-      "integrity": "sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.25.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-transform": "^1.10.3",
-        "prosemirror-view": "^1.39.1"
-      }
-    },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@remirror/core-constants": "3.0.0",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
-      "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8147,14 +7863,13 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.41.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
-      "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
+      "version": "1.41.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.9.tgz",
+      "integrity": "sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "prosemirror-model": "^1.20.0",
+        "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
@@ -8228,39 +7943,29 @@
         "node": ">=6"
       }
     },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/puppeteer-core": {
-      "version": "24.40.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
-      "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.0",
+        "@puppeteer/browsers": "2.13.2",
         "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1581282",
-        "typed-query-selector": "^2.12.1",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.1",
-        "ws": "^8.19.0"
+        "ws": "^8.20.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8280,9 +7985,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8411,12 +8116,13 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -8500,9 +8206,9 @@
       }
     },
     "node_modules/rettime": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
-      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8518,14 +8224,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -8534,32 +8240,32 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -8569,31 +8275,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -8712,9 +8418,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -8729,6 +8435,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -8741,20 +8448,21 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -8766,14 +8474,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8868,13 +8576,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -8898,13 +8606,13 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -8928,9 +8636,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9063,9 +8771,9 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9096,9 +8804,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9106,9 +8814,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9122,23 +8830,55 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tldts": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
-      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.27"
+        "tldts-core": "^7.4.2"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
-      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9181,10 +8921,17 @@
       }
     },
     "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -9231,9 +8978,9 @@
       }
     },
     "node_modules/typed-query-selector": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
-      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9289,13 +9036,6 @@
         "node": "*"
       }
     },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -9311,9 +9051,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9357,9 +9097,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -9397,17 +9137,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9423,7 +9163,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -9474,6 +9214,34 @@
         }
       }
     },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -9486,6 +9254,7 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -9498,19 +9267,27 @@
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -9518,6 +9295,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -9568,9 +9346,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -9646,19 +9424,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/ContentLock/Client/package-lock.json
+++ b/ContentLock/Client/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1245,6 +1245,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/ContentLock/Client/src/autoLock/contentlock.autolock.context.ts
+++ b/ContentLock/Client/src/autoLock/contentlock.autolock.context.ts
@@ -1,0 +1,158 @@
+import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT, UmbDocumentWorkspaceContext } from '@umbraco-cms/backoffice/document';
+import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
+import ContentLockSignalrContext, { CONTENTLOCK_SIGNALR_CONTEXT } from '../globalContexts/contentlock.signalr.context';
+
+export class ContentLockAutoLockContext extends UmbContextBase {
+
+    #docWorkspaceCtx?: UmbDocumentWorkspaceContext;
+    #signalRContext?: ContentLockSignalrContext;
+    #notificationCtx?: UmbNotificationContext;
+    #localize = new UmbLocalizationController(this);
+
+    #enabled = false;
+    #heartbeatThrottleMs = 60000;
+    #lastHeartbeat = 0;
+    #unique?: string;
+    #currentUserKey?: string;
+    #isNodeLocked = false;
+    #holdsAutoLock = false;
+
+    constructor(host: UmbControllerHost) {
+        super(host, CONTENTLOCK_AUTOLOCK_CONTEXT.toString());
+
+        this.consumeContext(UMB_NOTIFICATION_CONTEXT, (notificationCtx) => {
+            this.#notificationCtx = notificationCtx;
+        });
+
+        this.consumeContext(UMB_CURRENT_USER_CONTEXT, (currentUserCtx) => {
+            this.observe(currentUserCtx?.unique, (currentUserKey) => {
+                this.#currentUserKey = currentUserKey;
+            }, 'contentLockAutoLockCurrentUser');
+        });
+
+        this.consumeContext(CONTENTLOCK_SIGNALR_CONTEXT, (signalRContext) => {
+            this.#signalRContext = signalRContext;
+
+            this.observe(signalRContext?.EnableAutoLock, (enabled) => {
+                this.#enabled = enabled ?? false;
+            }, 'contentLockAutoLockEnabled');
+
+            this.observe(signalRContext?.AutoLockHeartbeatSeconds, (seconds) => {
+                this.#heartbeatThrottleMs = Math.max(5, seconds ?? 60) * 1000;
+            }, 'contentLockAutoLockHeartbeat');
+
+            this.observe(signalRContext?.lockUnlockedByUser, (evt) => this.#onUnlockedByOther(evt), 'contentLockAutoLockUnlockedByOther');
+        });
+
+        this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (docWorkspaceCtx) => {
+            this.#docWorkspaceCtx = docWorkspaceCtx;
+
+            this.observe(docWorkspaceCtx?.unique, (unique) => {
+                const next = unique ?? undefined;
+                if (next === this.#unique) return;
+
+                if (this.#holdsAutoLock && this.#unique) {
+                    this.#release(this.#unique);
+                }
+
+                this.#unique = next;
+                this.#observeLockState();
+            }, 'contentLockAutoLockUnique');
+
+            this.observe(docWorkspaceCtx?.data, () => this.#evaluate(), 'contentLockAutoLockData');
+        });
+    }
+
+    #observeLockState() {
+        if (!this.#signalRContext || !this.#unique) return;
+        this.observe(this.#signalRContext.isNodeLocked(this.#unique), (isLocked) => {
+            this.#isNodeLocked = isLocked;
+            if (!isLocked) {
+                // Lock removed elsewhere — drop our claim so a later edit re-acquires
+                this.#holdsAutoLock = false;
+            }
+        }, 'contentLockAutoLockIsLocked');
+    }
+
+    #onUnlockedByOther(evt?: { contentKey: string; unlockedByName: string; unlockedByKey: string }) {
+        if (!evt || !this.#holdsAutoLock) return;
+        if (evt.contentKey !== this.#unique) return;
+        if (evt.unlockedByKey?.toLowerCase() === this.#currentUserKey?.toLowerCase()) return;
+
+        this.#holdsAutoLock = false;
+        this.#notificationCtx?.peek('warning', {
+            data: {
+                headline: this.#localize.term('contentLockNotification_unlockedByOtherHeader'),
+                message: this.#localize.term('contentLockNotification_unlockedByOtherMessage', evt.unlockedByName),
+            }
+        });
+    }
+
+    #evaluate() {
+        if (!this.#enabled || !this.#unique) return;
+        if (this.#docWorkspaceCtx?.getIsNew()) return;
+
+        const dirty = this.#docWorkspaceCtx?.getHasUnpersistedChanges() ?? false;
+
+        if (dirty) {
+            if (!this.#holdsAutoLock && !this.#isNodeLocked) {
+                this.#acquire();
+            } else if (this.#holdsAutoLock) {
+                this.#heartbeat();
+            }
+        } else if (this.#holdsAutoLock) {
+            this.#release();
+        }
+    }
+
+    async #acquire() {
+        const connection = this.#signalRContext?.signalrConnection;
+        if (!connection || !this.#unique) return;
+
+        this.#holdsAutoLock = true;
+        this.#lastHeartbeat = Date.now();
+        try {
+            await connection.invoke('AcquireAutoLock', this.#unique);
+        } catch {
+            this.#holdsAutoLock = false;
+        }
+    }
+
+    #heartbeat() {
+        const now = Date.now();
+        if (now - this.#lastHeartbeat < this.#heartbeatThrottleMs) return;
+        this.#lastHeartbeat = now;
+
+        const connection = this.#signalRContext?.signalrConnection;
+        if (connection && this.#unique) {
+            connection.invoke('AutoLockHeartbeat', this.#unique).catch(() => { });
+        }
+    }
+
+    async #release(unique = this.#unique) {
+        if (!this.#holdsAutoLock) return;
+        this.#holdsAutoLock = false;
+
+        const connection = this.#signalRContext?.signalrConnection;
+        if (!connection || !unique) return;
+        try {
+            await connection.invoke('ReleaseAutoLock', unique);
+        } catch {
+            // Server-side disconnect cleanup / inactivity timeout releases it if this call fails
+        }
+    }
+
+    override destroy(): void {
+        this.#release(this.#unique);
+        super.destroy();
+    }
+}
+
+export const api = ContentLockAutoLockContext;
+
+export const CONTENTLOCK_AUTOLOCK_CONTEXT = new UmbContextToken<ContentLockAutoLockContext>('ContentLockAutoLockContext');

--- a/ContentLock/Client/src/autoLock/manifest.ts
+++ b/ContentLock/Client/src/autoLock/manifest.ts
@@ -1,0 +1,18 @@
+import { UMB_DOCUMENT_WORKSPACE_ALIAS } from '@umbraco-cms/backoffice/document';
+import { UMB_WORKSPACE_CONDITION_ALIAS } from '@umbraco-cms/backoffice/workspace';
+
+export const manifests: Array<UmbExtensionManifest> = [
+    {
+        alias: 'ContentLock.AutoLockWorkspaceContext',
+        name: '[Content Lock] Auto Lock Workspace Context',
+        type: 'workspaceContext',
+        js: () => import('./contentlock.autolock.context'),
+        weight: 190,
+        conditions: [
+            {
+                alias: UMB_WORKSPACE_CONDITION_ALIAS,
+                match: UMB_DOCUMENT_WORKSPACE_ALIAS,
+            }
+        ]
+    }
+];

--- a/ContentLock/Client/src/bundle.manifests.ts
+++ b/ContentLock/Client/src/bundle.manifests.ts
@@ -9,6 +9,7 @@ import { manifests as modals } from './modals/manifest';
 import { manifests as userPermissions } from './userpermissions/manifest';
 import { manifests as workspaceActions } from './workspaceActions/manifest';
 import { manifests as workspaceContexts } from './workspaceContexts/manifest';
+import { manifests as autoLock } from './autoLock/manifest';
 import { manifests as workspaceFooterApps } from './workspaceFooterApp/manifest';
 import { manifests as entitySigns } from './entitySigns/manifest';
 import { manifests as icons } from './icons/manifest';
@@ -27,6 +28,7 @@ export const manifests: Array<UmbExtensionManifest> = [
   ...userPermissions,
   ...workspaceActions,
   ...workspaceContexts,
+  ...autoLock,
   ...workspaceFooterApps,
   ...entitySigns,
   ...icons

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -35,6 +35,10 @@ export default class ContentLockSignalrContext extends UmbContextBase
     // Tracks which users are currently in an active WebRTC call (by user key)
     #inCallUserKeys = new UmbArrayState<string>([], (item) => item);
 
+    // Last "lock unlocked by another user" event, so the auto-lock context can warn the holder
+    #lockUnlockedByUser = new UmbObjectState<{ contentKey: string; unlockedByName: string; unlockedByKey: string } | undefined>(undefined);
+    public lockUnlockedByUser = this.#lockUnlockedByUser.asObservable();
+
     // Used to store the options for the content lock package
     // Sets the default values for the options
     #contentLockOptions = new UmbObjectState<ContentLockOptions>(
@@ -59,6 +63,11 @@ export default class ContentLockSignalrContext extends UmbContextBase
                     ringbackSound: '/App_Plugins/ContentLock/sounds/ringtone.mp3',
                     ringSound: '/App_Plugins/ContentLock/sounds/ringtone.mp3',
                 }
+            },
+            autoLock: {
+                enable: false,
+                inactivityTimeoutSeconds: 300,
+                heartbeatSeconds: 60,
             }
         });
 
@@ -102,6 +111,9 @@ export default class ContentLockSignalrContext extends UmbContextBase
 
     // The individual options as observables
     public EnableWebRTC = this.#contentLockOptions.asObservablePart(options => options.webRTC.enable);
+    public EnableAutoLock = this.#contentLockOptions.asObservablePart(options => options.autoLock.enable);
+    public AutoLockTimeoutSeconds = this.#contentLockOptions.asObservablePart(options => options.autoLock.inactivityTimeoutSeconds);
+    public AutoLockHeartbeatSeconds = this.#contentLockOptions.asObservablePart(options => options.autoLock.heartbeatSeconds);
     public EnableOnlineUsers = this.#contentLockOptions.asObservablePart(options => options.onlineUsers.enable);
     public EnableSounds = this.#contentLockOptions.asObservablePart(options => options.onlineUsers.sounds.enable);
     public LoginSound = this.#contentLockOptions.asObservablePart(options => options.onlineUsers.sounds.loginSound);
@@ -234,6 +246,11 @@ export default class ContentLockSignalrContext extends UmbContextBase
                     // Reload tree item - will fetch from server again and thus remove the Locked Flag/Sign info
                     this.#emitReloadTreeEvent(key);
                 }
+            });
+
+            // A user explicitly unlocked a node - surfaced so the auto-lock holder can be warned who removed it
+            this.signalrConnection.on('ReceiveLockUnlockedByUser', (contentKey: string, unlockedByName: string, unlockedByKey: string) => {
+                this.#lockUnlockedByUser.setValue({ contentKey, unlockedByName, unlockedByKey });
             });
 
             // Purely for E2E tests only SignalR server will send out a 'RemoveAllLocksToClients'

--- a/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
+++ b/ContentLock/Client/src/globalContexts/contentlock.signalr.context.ts
@@ -39,6 +39,10 @@ export default class ContentLockSignalrContext extends UmbContextBase
     #lockUnlockedByUser = new UmbObjectState<{ contentKey: string; unlockedByName: string; unlockedByKey: string } | undefined>(undefined);
     public lockUnlockedByUser = this.#lockUnlockedByUser.asObservable();
 
+    // Last "content was saved while locked, reload suggested" event, with the time it arrived so stale replays are ignored
+    #suggestReload = new UmbObjectState<{ contentKey: string; changedByKey: string; at: number } | undefined>(undefined);
+    public suggestReload = this.#suggestReload.asObservable();
+
     // Used to store the options for the content lock package
     // Sets the default values for the options
     #contentLockOptions = new UmbObjectState<ContentLockOptions>(
@@ -66,7 +70,6 @@ export default class ContentLockSignalrContext extends UmbContextBase
             },
             autoLock: {
                 enable: false,
-                inactivityTimeoutSeconds: 300,
                 heartbeatSeconds: 60,
             }
         });
@@ -112,7 +115,6 @@ export default class ContentLockSignalrContext extends UmbContextBase
     // The individual options as observables
     public EnableWebRTC = this.#contentLockOptions.asObservablePart(options => options.webRTC.enable);
     public EnableAutoLock = this.#contentLockOptions.asObservablePart(options => options.autoLock.enable);
-    public AutoLockTimeoutSeconds = this.#contentLockOptions.asObservablePart(options => options.autoLock.inactivityTimeoutSeconds);
     public AutoLockHeartbeatSeconds = this.#contentLockOptions.asObservablePart(options => options.autoLock.heartbeatSeconds);
     public EnableOnlineUsers = this.#contentLockOptions.asObservablePart(options => options.onlineUsers.enable);
     public EnableSounds = this.#contentLockOptions.asObservablePart(options => options.onlineUsers.sounds.enable);
@@ -251,6 +253,11 @@ export default class ContentLockSignalrContext extends UmbContextBase
             // A user explicitly unlocked a node - surfaced so the auto-lock holder can be warned who removed it
             this.signalrConnection.on('ReceiveLockUnlockedByUser', (contentKey: string, unlockedByName: string, unlockedByKey: string) => {
                 this.#lockUnlockedByUser.setValue({ contentKey, unlockedByName, unlockedByKey });
+            });
+
+            // A released lock had saved changes - other viewers of that node should be prompted to reload
+            this.signalrConnection.on('ReceiveSuggestReload', (contentKey: string, changedByKey: string) => {
+                this.#suggestReload.setValue({ contentKey, changedByKey, at: Date.now() });
             });
 
             // Purely for E2E tests only SignalR server will send out a 'RemoveAllLocksToClients'

--- a/ContentLock/Client/src/interfaces/ContentLockOptions.ts
+++ b/ContentLock/Client/src/interfaces/ContentLockOptions.ts
@@ -7,7 +7,6 @@ export interface ContentLockOptions {
 
 export interface AutoLockOptions {
     enable: boolean;
-    inactivityTimeoutSeconds: number;
     heartbeatSeconds: number;
 }
 

--- a/ContentLock/Client/src/interfaces/ContentLockOptions.ts
+++ b/ContentLock/Client/src/interfaces/ContentLockOptions.ts
@@ -2,6 +2,13 @@ export interface ContentLockOptions {
     onlineUsers: OnlineUsersOptions;
     signalRClientLogLevel: string;
     webRTC: WebRTCOptions;
+    autoLock: AutoLockOptions;
+}
+
+export interface AutoLockOptions {
+    enable: boolean;
+    inactivityTimeoutSeconds: number;
+    heartbeatSeconds: number;
 }
 
 export interface OnlineUsersOptions {

--- a/ContentLock/Client/src/localizations/cy.ts
+++ b/ContentLock/Client/src/localizations/cy.ts
@@ -22,6 +22,8 @@
         unlockedMessage: 'Mae\'r ddogfen wedi\'i datgloi i ganiatáu i ddefnyddwyr eraill ei golygu.',
         bulkUnlockHeader: 'Cynnwys wedi\'i Ddatgloi',
         bulkUnlockMessage: 'Mae\'r cynnwys a ddewiswyd wedi\'i ddatgloi\'n llwyddiannus',
+        unlockedByOtherHeader: 'Clo Wedi\'i Dynnu',
+        unlockedByOtherMessage: 'Mae {0} wedi datgloi\'r dudalen hon. Nid yw eich newidiadau wedi\'u diogelu mwyach.',
     },
     contentLockPermission: {
         group: 'Content Lock', // TODO: Currently not used in Umbraco but added for future use

--- a/ContentLock/Client/src/localizations/dk.ts
+++ b/ContentLock/Client/src/localizations/dk.ts
@@ -22,6 +22,8 @@ export default {
         unlockedMessage: 'Dokumentet er blevet låst op, så andre brugere kan redigere det.',
         bulkUnlockHeader: 'Indhold låst op',
         bulkUnlockMessage: 'Det valgte indhold er blevet låst op',
+        unlockedByOtherHeader: 'Lås fjernet',
+        unlockedByOtherMessage: '{0} har låst denne side op. Dine ændringer er ikke længere beskyttet.',
     },
     contentLockPermission: {
         group: 'Content Lock', // TODO: Currently not used in Umbraco but added for future use

--- a/ContentLock/Client/src/localizations/en.ts
+++ b/ContentLock/Client/src/localizations/en.ts
@@ -21,7 +21,9 @@ export default {
         unlockedHeader: 'Content Unlocked',
         unlockedMessage: 'The document has been unlocked, to allow other users to edit.',
         bulkUnlockHeader: 'Content Unlocked',
-        bulkUnlockMessage: 'The selected content has been unlocked successfully'
+        bulkUnlockMessage: 'The selected content has been unlocked successfully',
+        unlockedByOtherHeader: 'Lock Removed',
+        unlockedByOtherMessage: '{0} has unlocked this page. Your changes are no longer protected.'
     },
     contentLockPermission: {
         group: 'Content Lock', // TODO: Currently not used in Umbraco but added for future use

--- a/ContentLock/Client/src/localizations/fr.ts
+++ b/ContentLock/Client/src/localizations/fr.ts
@@ -21,7 +21,9 @@ export default {
         unlockedHeader: 'Contenu déverrouillé',
         unlockedMessage: 'Le document a été déverrouillé pour permettre à d’autres utilisateurs de le modifier.',
         bulkUnlockHeader: 'Contenu déverrouillé',
-        bulkUnlockMessage: 'Le contenu sélectionné a été déverrouillé avec succès'
+        bulkUnlockMessage: 'Le contenu sélectionné a été déverrouillé avec succès',
+        unlockedByOtherHeader: 'Verrou supprimé',
+        unlockedByOtherMessage: '{0} a déverrouillé cette page. Vos modifications ne sont plus protégées.'
     },
     contentLockPermission: {
         group: 'Content Lock', // TODO: Currently not used in Umbraco but added for future use

--- a/ContentLock/Client/src/localizations/it.ts
+++ b/ContentLock/Client/src/localizations/it.ts
@@ -22,6 +22,8 @@ export default {
         unlockedMessage: 'Il documento è stato sbloccato per consentire ad altri utenti di modificarlo.',
         bulkUnlockHeader: 'Contenuto sbloccato',
         bulkUnlockMessage: 'Il contenuto selezionato è stato sbloccato con successo',
+        unlockedByOtherHeader: 'Blocco rimosso',
+        unlockedByOtherMessage: '{0} ha sbloccato questa pagina. Le tue modifiche non sono più protette.',
     },
     contentLockPermission: {
         group: 'Content Lock', // TODO: Currently not used in Umbraco but added for future use

--- a/ContentLock/Client/src/localizations/nl.ts
+++ b/ContentLock/Client/src/localizations/nl.ts
@@ -22,6 +22,8 @@ export default {
         unlockedMessage: 'Het document is ontgrendeld zodat andere gebruikers het kunnen bewerken.',
         bulkUnlockHeader: 'Inhoud ontgrendeld',
         bulkUnlockMessage: 'De geselecteerde inhoud is succesvol ontgrendeld',
+        unlockedByOtherHeader: 'Vergrendeling verwijderd',
+        unlockedByOtherMessage: '{0} heeft deze pagina ontgrendeld. Je wijzigingen zijn niet langer beschermd.',
     },
     contentLockPermission: {
         group: 'Content Lock', // TODO: Currently not used in Umbraco but added for future use

--- a/ContentLock/Client/src/localizations/no.ts
+++ b/ContentLock/Client/src/localizations/no.ts
@@ -21,7 +21,9 @@ export default {
         unlockedHeader: 'Innhold låst opp',
         unlockedMessage: 'Dette dokumentet er låst opp slik at andre brukere kan redigere det.',
         bulkUnlockHeader: 'Innhold låst opp',
-        bulkUnlockMessage: 'Valgt innhold er låst opp'
+        bulkUnlockMessage: 'Valgt innhold er låst opp',
+        unlockedByOtherHeader: 'Lås fjernet',
+        unlockedByOtherMessage: '{0} har låst opp denne siden. Endringene dine er ikke lenger beskyttet.'
     },
     contentLockPermission: {
         group: 'Innholdslås', // TODO: Currently not used in Umbraco but added for future use

--- a/ContentLock/Client/src/localizations/tr.ts
+++ b/ContentLock/Client/src/localizations/tr.ts
@@ -21,7 +21,9 @@ export default {
         unlockedHeader: "İçerik Kilidi Açıldı",
         unlockedMessage: "Belgenin kilidi, diğer kullanıcıların düzenlemesine izin vermek için, açıldı.",
         bulkUnlockHeader: "İçerik Kilidi Açıldı",
-        bulkUnlockMessage: "Seçilen içeriğin kilidi başarıyla açıldı"
+        bulkUnlockMessage: "Seçilen içeriğin kilidi başarıyla açıldı",
+        unlockedByOtherHeader: "Kilit Kaldırıldı",
+        unlockedByOtherMessage: "{0} bu sayfanın kilidini açtı. Değişiklikleriniz artık korunmuyor."
     },
     contentLockPermission: {
         group: "İçerik Kilidi",

--- a/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
+++ b/ContentLock/Client/src/workspaceContexts/contentlock.workspace.context.ts
@@ -31,6 +31,9 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
 
     #localize = new UmbLocalizationController(this);
 
+    // Timestamp of the last reload event we acted on; ignores stale replays and the same event being re-emitted
+    #handledReloadAt = Date.now();
+
 	constructor(host: UmbControllerHost) {
 		super(host, CONTENTLOCK_WORKSPACE_CONTEXT.toString());
 
@@ -63,8 +66,26 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
 
         if (this.#signalRContext) {
 
-            let previousState = { isLocked: false, isLockedBySelf: false }; 
-            
+            // Prompt to reload only when a released lock actually saved changes (and not for the editor who made them)
+            this.observe(this.#signalRContext.suggestReload, (evt) => {
+                if (!evt || evt.at <= this.#handledReloadAt) return;
+                if (evt.contentKey !== this.#unique?.toString()) return;
+                if (evt.changedByKey?.toLowerCase() === this.#currentUserKey?.toLowerCase()) return;
+
+                this.#handledReloadAt = evt.at;
+
+                umbOpenModal(this, UMB_CONFIRM_MODAL, {
+                    data: {
+                        headline: this.#localize.term('contentUnlockedModal_modalHeader'),
+                        content: this.#localize.term('contentUnlockedModal_modalContent'),
+                        color: 'positive',
+                        confirmLabel: this.#localize.term('contentUnlockedModal_reload'),
+                    }
+                })
+                .then(async () => { await this.#docWorkspaceCtx?.reload(); })
+                .catch(() => { });
+            }, 'contentLockSuggestReload');
+
             // Observe the 3 states from the SignalR context
             // isLocked: boolean - Is the item locked by anyone
             // isLockedBySelf: boolean - Is the item locked by the current user
@@ -73,7 +94,7 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                 this.#signalRContext.isNodeLocked(this.#unique.toString()),
                 this.#signalRContext.isNodeLockedByMe(this.#unique.toString(), this.#currentUserKey),
                 this.#signalRContext.getLock(this.#unique.toString())
-            ]), async ([isLocked, isLockedBySelf, lockInfo]) => {
+            ]), ([isLocked, isLockedBySelf, lockInfo]) => {
 
                 // Set the observables
                 this.setIsLocked(isLocked);
@@ -109,32 +130,6 @@ export class ContentLockWorkspaceContext extends UmbContextBase {
                     this.#docWorkspaceCtx?.readOnlyGuard.removeRules(ruleKeys);
                 }
 
-                // If previously the page was locked by someone else, we can alert the user its now unlocked
-                if (previousState.isLocked && !previousState.isLockedBySelf && !isLocked && !isLockedBySelf) {
-                    umbOpenModal(this, UMB_CONFIRM_MODAL,
-                        {
-                            data: {
-                                headline: this.#localize.term('contentUnlockedModal_modalHeader'),
-                                content: this.#localize.term('contentUnlockedModal_modalContent'),
-                                color: "positive",
-                                confirmLabel: this.#localize.term('contentUnlockedModal_reload'),
-                            }
-                        }
-                    )
-                    .then(async () => {
-                        // This will reload the entire page, so the user can see the latest version of the content
-                        // Might be nice if we can just ask a context to reload the node or something?
-
-                        // There is reload on Workspace context
-                        await this.#docWorkspaceCtx?.reload();
-                    })
-                    .catch(() => {
-                        // Do nothing if the user cancels the modal or presses escape etc
-                    });
-                }
-
-                // Update the previous state
-                previousState = { isLocked, isLockedBySelf };
             });
         }
     }

--- a/ContentLock/Composers/ContentLockNotificationComposer.cs
+++ b/ContentLock/Composers/ContentLockNotificationComposer.cs
@@ -12,5 +12,6 @@ public class ContentLockNotificationComposer : IComposer
     {
         builder.AddNotificationAsyncHandler<ContentMovingToRecycleBinNotification, ContentMovingToRecycleBinHandler>();
         builder.AddNotificationAsyncHandler<ContentDeletingNotification, ContentDeletingNotificationHandler>();
+        builder.AddNotificationAsyncHandler<ContentSavedNotification, ContentSavedNotificationHandler>();
     }
 }

--- a/ContentLock/Controllers/ContentLockApiController.cs
+++ b/ContentLock/Controllers/ContentLockApiController.cs
@@ -92,6 +92,9 @@ namespace ContentLock.Controllers
 
             await _contentLockService.UnlockContentAsync(key, userKey.Value);
 
+            // Sent before the removal below so an auto-lock holder's client still knows it held the lock
+            await _contentLockHubContext.Clients.All.ReceiveLockUnlockedByUser(key, currentUser?.Name ?? "Unknown", userKey.Value);
+
             // Use SignalR to send out to ALL clients that a single node has been unlocked
             // Then the underlying observable object with the count & array can be updated
             await _contentLockHubContext.Clients.All.RemoveLockToClients(key);
@@ -117,13 +120,18 @@ namespace ContentLock.Controllers
                     .Build());
             }
 
-            var userKey = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Key;
+            var currentUser = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
+            var userKey = currentUser?.Key;
+            var userName = currentUser?.Name ?? "Unknown";
 
             // For each item posted to bulk unlock
             foreach (var contentKey in keys)
             {
                 // Call unlock on service
                 await _contentLockService.UnlockContentAsync(contentKey, userKey.Value);
+
+                // Sent before the removal below so an auto-lock holder's client still knows it held the lock
+                await _contentLockHubContext.Clients.All.ReceiveLockUnlockedByUser(contentKey, userName, userKey.Value);
             }
 
             // Use SignalR to send out to ALL clients that many node/s has been unlocked

--- a/ContentLock/Interfaces/IContentLockHubEvents.cs
+++ b/ContentLock/Interfaces/IContentLockHubEvents.cs
@@ -35,6 +35,11 @@ public interface IContentLockHubEvents
     public Task ReceiveLockUnlockedByUser(Guid contentKey, string unlockedByName, Guid unlockedByKey);
 
     /// <summary>
+    /// Sent only when a released lock had actual saved changes, so other users viewing the node are prompted to reload.
+    /// </summary>
+    public Task ReceiveSuggestReload(Guid contentKey, Guid changedByKey);
+
+    /// <summary>
     /// This is used for E2E testing purposes only
     /// Where the ResetContentLocksAsync method will call this to get clients to remove all locks
     /// </summary>

--- a/ContentLock/Interfaces/IContentLockHubEvents.cs
+++ b/ContentLock/Interfaces/IContentLockHubEvents.cs
@@ -30,6 +30,11 @@ public interface IContentLockHubEvents
     public Task RemoveLocksToClients(IEnumerable<Guid> contentKeys);
 
     /// <summary>
+    /// Sent when a user explicitly unlocks a node, so a user holding an auto-lock on it can be warned who removed it.
+    /// </summary>
+    public Task ReceiveLockUnlockedByUser(Guid contentKey, string unlockedByName, Guid unlockedByKey);
+
+    /// <summary>
     /// This is used for E2E testing purposes only
     /// Where the ResetContentLocksAsync method will call this to get clients to remove all locks
     /// </summary>

--- a/ContentLock/Interfaces/IContentLockService.cs
+++ b/ContentLock/Interfaces/IContentLockService.cs
@@ -9,7 +9,8 @@ namespace ContentLock.Interfaces
         /// </summary>
         /// <param name="contentKey">The content node key to lock</param>
         /// <param name="userKey">The user key, requesting to lock the node</param>
-        Task<ContentLockOverviewItem> LockContentAsync(Guid contentKey, Guid userKey);
+        /// <param name="isAutoLock">True when the lock is created automatically on edit rather than by an explicit user action</param>
+        Task<ContentLockOverviewItem> LockContentAsync(Guid contentKey, Guid userKey, bool isAutoLock = false);
 
         /// <summary>
         /// Unlock a content node
@@ -17,6 +18,13 @@ namespace ContentLock.Interfaces
         /// <param name="contentKey"></param>
         /// <param name="userKey"></param>
         Task UnlockContentAsync(Guid contentKey, Guid userKey);
+
+        /// <summary>
+        /// Releases a lock only if it is an auto-lock held by the given user.
+        /// Manual locks are never removed by this method.
+        /// </summary>
+        /// <returns>True if an auto-lock was removed; otherwise false.</returns>
+        Task<bool> ReleaseAutoLockAsync(Guid contentKey, Guid userKey);
 
         /// <summary>
         /// Gets a status of a lock

--- a/ContentLock/Migrations/ContentLockMigrationPlan.cs
+++ b/ContentLock/Migrations/ContentLockMigrationPlan.cs
@@ -1,4 +1,5 @@
 ﻿using ContentLock.Migrations.v1;
+using ContentLock.Migrations.v2;
 using Umbraco.Cms.Core.Packaging;
 
 namespace ContentLock.Migrations
@@ -13,7 +14,8 @@ namespace ContentLock.Migrations
         {
             From(InitialState)
                 .To<InitDatabaseTable>("ContentLock.InitDbTables")
-                .To<AddUserPermissionToAdmins>("ContentLock.AddUserPermissionToAdmins");
+                .To<AddUserPermissionToAdmins>("ContentLock.AddUserPermissionToAdmins")
+                .To<AddIsAutoLockColumn>("ContentLock.AddIsAutoLockColumn");
         }
     }
 }

--- a/ContentLock/Migrations/v2/AddIsAutoLockColumn.cs
+++ b/ContentLock/Migrations/v2/AddIsAutoLockColumn.cs
@@ -1,0 +1,31 @@
+using ContentLock.Models.Database;
+
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace ContentLock.Migrations.v2;
+
+public class AddIsAutoLockColumn : AsyncMigrationBase
+{
+    public AddIsAutoLockColumn(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override Task MigrateAsync()
+    {
+        if (TableExists(ContentLocks.TableName) is false)
+        {
+            return Task.CompletedTask;
+        }
+
+        const string columnName = "IsAutoLock";
+        var hasColumn = Context.SqlContext.SqlSyntax.GetColumnsInSchema(Context.Database)
+            .Any(c => c.TableName == ContentLocks.TableName && c.ColumnName == columnName);
+
+        if (hasColumn is false)
+        {
+            AddColumn<ContentLocks>(ContentLocks.TableName, columnName);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/ContentLock/Models/Database/ContentLocks.cs
+++ b/ContentLock/Models/Database/ContentLocks.cs
@@ -23,5 +23,9 @@ namespace ContentLock.Models.Database
         [NullSetting(NullSetting = NullSettings.NotNull)]
         public DateTime LockedAtDate { get; set; }
 
+        [Column("IsAutoLock")]
+        [NullSetting(NullSetting = NullSettings.NotNull)]
+        [Constraint(Default = 0)]
+        public bool IsAutoLock { get; set; }
     }
 }

--- a/ContentLock/Notifications/ContentSavedNotificationHandler.cs
+++ b/ContentLock/Notifications/ContentSavedNotificationHandler.cs
@@ -1,0 +1,44 @@
+using ContentLock.Interfaces;
+using ContentLock.SignalR;
+
+using Microsoft.AspNetCore.SignalR;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Security;
+
+namespace ContentLock.Notifications;
+
+public class ContentSavedNotificationHandler : INotificationAsyncHandler<ContentSavedNotification>
+{
+    private readonly IContentLockService _contentLockService;
+    private readonly IHubContext<ContentLockHub, IContentLockHubEvents> _contentLockHubContext;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public ContentSavedNotificationHandler(
+        IContentLockService contentLockService,
+        IHubContext<ContentLockHub, IContentLockHubEvents> contentLockHubContext,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _contentLockService = contentLockService;
+        _contentLockHubContext = contentLockHubContext;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    public async Task HandleAsync(ContentSavedNotification notification, CancellationToken cancellationToken)
+    {
+        var savedKeys = notification.SavedEntities.Select(x => x.Key).ToHashSet();
+        var lockedKeys = await _contentLockService.GetLockedContentKeysAsync(savedKeys);
+        if (lockedKeys.Count == 0)
+        {
+            return;
+        }
+
+        // The editor who saved is the lock holder; other users viewing the node are prompted to reload (and skip this user)
+        var changedByKey = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Key ?? Umbraco.Cms.Core.Constants.Security.SuperUserKey;
+        foreach (var contentKey in lockedKeys)
+        {
+            await _contentLockHubContext.Clients.All.ReceiveSuggestReload(contentKey, changedByKey);
+        }
+    }
+}

--- a/ContentLock/Options/ContentLockOptions.cs
+++ b/ContentLock/Options/ContentLockOptions.cs
@@ -13,6 +13,11 @@ public class ContentLockOptions
     /// Settings related to the WebRTC audio calling feature between backoffice users
     /// </summary>
     public WebRTCOptions WebRTC { get; set; } = new();
+
+    /// <summary>
+    /// Settings related to automatically locking a node while a user is editing it
+    /// </summary>
+    public AutoLockOptions AutoLock { get; set; } = new();
     
     /// <summary>
     /// Used to set the log level of the SignalR Javascript client
@@ -59,6 +64,26 @@ public class ContentLockOptions
             /// </summary>
             public string LogoutSound { get; set; } = "/App_Plugins/ContentLock/sounds/logout.mp3";
         }
+    }
+
+    public class AutoLockOptions
+    {
+        /// <summary>
+        /// Enable or disable automatically locking a node when a user starts editing it.
+        /// Reactively applied without restart. Disabled by default.
+        /// </summary>
+        public bool Enable { get; set; } = false;
+
+        /// <summary>
+        /// Seconds of editing inactivity after which an auto-lock is released.
+        /// </summary>
+        public int InactivityTimeoutSeconds { get; set; } = 300;
+
+        /// <summary>
+        /// How often (seconds) the client refreshes its auto-lock while editing. Should be less than
+        /// <see cref="InactivityTimeoutSeconds"/> so an actively edited lock is not released.
+        /// </summary>
+        public int HeartbeatSeconds { get; set; } = 60;
     }
 
     public class WebRTCOptions

--- a/ContentLock/Services/ContentLockService.cs
+++ b/ContentLock/Services/ContentLockService.cs
@@ -121,7 +121,7 @@ namespace ContentLock.Services
             }
         }
 
-        public async Task<ContentLockOverviewItem> LockContentAsync(Guid contentKey, Guid userKey)
+        public async Task<ContentLockOverviewItem> LockContentAsync(Guid contentKey, Guid userKey, bool isAutoLock = false)
         {
             _logger.LogInformation("Locking content {contentKey} for user {userKey}", contentKey, userKey);
 
@@ -130,10 +130,11 @@ namespace ContentLock.Services
             {
                 using (var scope = _scopeProvider.CreateScope(autoComplete: true))
                 {
-                    await scope.Database.SaveAsync(new ContentLocks { 
+                    await scope.Database.SaveAsync(new ContentLocks {
                         ContentKey = contentKey,
                         UserKey = userKey,
-                        LockedAtDate = now
+                        LockedAtDate = now,
+                        IsAutoLock = isAutoLock
                     });
                 }
 
@@ -193,6 +194,33 @@ namespace ContentLock.Services
             {
                 _logger.LogError(ex, "Error unlocking content {contentKey} for user {userKey}", contentKey, userKey);
                 throw new ContentLockException($"Error unlocking content {contentKey} for user {userKey}", ex);
+            }
+        }
+
+        public async Task<bool> ReleaseAutoLockAsync(Guid contentKey, Guid userKey)
+        {
+            try
+            {
+                using (var scope = _scopeProvider.CreateScope(autoComplete: true))
+                {
+                    var existing = scope.Database.SingleOrDefaultById<ContentLocks>(contentKey);
+                    if (existing is null || existing.UserKey != userKey || existing.IsAutoLock is false)
+                    {
+                        return false;
+                    }
+
+                    await scope.Database.DeleteAsync(existing);
+                }
+
+                var contentNodeAsAnId = _idKeyMap.GetIdForKey(contentKey, UmbracoObjectTypes.Document).Result;
+                await _auditService.AddAsync(AuditType.Custom, userKey, contentNodeAsAnId, Umbraco.Cms.Core.Constants.ObjectTypes.Strings.Document, "Page Unlocked", "Page Unlocked");
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error releasing auto-lock for content {contentKey} for user {userKey}", contentKey, userKey);
+                throw new ContentLockException($"Error releasing auto-lock for content {contentKey} for user {userKey}", ex);
             }
         }
 

--- a/ContentLock/SignalR/ContentLockHub.AutoLock.cs
+++ b/ContentLock/SignalR/ContentLockHub.AutoLock.cs
@@ -1,0 +1,133 @@
+using System.Collections.Concurrent;
+
+using Umbraco.Cms.Core.Collections;
+using Umbraco.Extensions;
+
+namespace ContentLock.SignalR;
+
+public partial class ContentLockHub
+{
+    private static readonly ConcurrentDictionary<string, ConcurrentHashSet<Guid>> AutoLocksByConnection = new();
+
+    private static readonly ConcurrentDictionary<Guid, AutoLockTimeout> AutoLockTimeouts = new();
+
+    private sealed record AutoLockTimeout(string ConnectionId, Guid UserKey, CancellationTokenSource Cts);
+
+    public async Task AcquireAutoLock(Guid contentKey)
+    {
+        if (!_options.CurrentValue.AutoLock.Enable)
+        {
+            return;
+        }
+
+        var userKey = this.Context.User?.GetUmbracoIdentity()?.GetUserKey();
+        if (!userKey.HasValue)
+        {
+            return;
+        }
+
+        var lockInfo = await _contentLockService.GetLockInfoAsync(contentKey, userKey.Value);
+        if (lockInfo.IsLocked)
+        {
+            return;
+        }
+
+        var lockedContentInfo = await _contentLockService.LockContentAsync(contentKey, userKey.Value, isAutoLock: true);
+
+        AutoLocksByConnection.GetOrAdd(this.Context.ConnectionId, _ => new ConcurrentHashSet<Guid>()).TryAdd(contentKey);
+        StartAutoLockTimeout(contentKey, this.Context.ConnectionId, userKey.Value);
+
+        await Clients.All.AddLockToClients(lockedContentInfo);
+    }
+
+    public async Task ReleaseAutoLock(Guid contentKey)
+    {
+        var userKey = this.Context.User?.GetUmbracoIdentity()?.GetUserKey();
+        if (!userKey.HasValue)
+        {
+            return;
+        }
+
+        if (!AutoLocksByConnection.TryGetValue(this.Context.ConnectionId, out var keys) || !keys.Contains(contentKey))
+        {
+            return;
+        }
+
+        CancelAutoLockTimeout(contentKey);
+        keys.Remove(contentKey);
+
+        if (await _contentLockService.ReleaseAutoLockAsync(contentKey, userKey.Value))
+        {
+            await Clients.All.RemoveLockToClients(contentKey);
+        }
+    }
+
+    public Task AutoLockHeartbeat(Guid contentKey)
+    {
+        if (AutoLockTimeouts.TryGetValue(contentKey, out var entry) && entry.ConnectionId == this.Context.ConnectionId)
+        {
+            StartAutoLockTimeout(contentKey, entry.ConnectionId, entry.UserKey);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task CleanUpAutoLocksOnDisconnectAsync(Guid? userKey, string connectionId)
+    {
+        if (!userKey.HasValue || !AutoLocksByConnection.TryRemove(connectionId, out var keys))
+        {
+            return;
+        }
+
+        foreach (var contentKey in keys.ToArray())
+        {
+            CancelAutoLockTimeout(contentKey);
+
+            if (await _contentLockService.ReleaseAutoLockAsync(contentKey, userKey.Value))
+            {
+                await Clients.All.RemoveLockToClients(contentKey);
+            }
+        }
+    }
+
+    private void StartAutoLockTimeout(Guid contentKey, string connectionId, Guid userKey)
+    {
+        CancelAutoLockTimeout(contentKey);
+
+        var cts = new CancellationTokenSource();
+        AutoLockTimeouts[contentKey] = new AutoLockTimeout(connectionId, userKey, cts);
+        _ = HandleAutoLockTimeoutAsync(contentKey, connectionId, userKey, cts.Token);
+    }
+
+    private async Task HandleAutoLockTimeoutAsync(Guid contentKey, string connectionId, Guid userKey, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(_options.CurrentValue.AutoLock.InactivityTimeoutSeconds), ct);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        AutoLockTimeouts.TryRemove(contentKey, out _);
+        if (AutoLocksByConnection.TryGetValue(connectionId, out var keys))
+        {
+            keys.Remove(contentKey);
+        }
+
+        if (await _contentLockService.ReleaseAutoLockAsync(contentKey, userKey))
+        {
+            await _hubContext.Clients.All.RemoveLockToClients(contentKey);
+        }
+    }
+
+    private static void CancelAutoLockTimeout(Guid contentKey)
+    {
+        if (AutoLockTimeouts.TryRemove(contentKey, out var entry))
+        {
+            entry.Cts.Cancel();
+            entry.Cts.Dispose();
+        }
+    }
+}

--- a/ContentLock/SignalR/ContentLockHub.cs
+++ b/ContentLock/SignalR/ContentLockHub.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 namespace ContentLock.SignalR;
 
 [Authorize(Policy = AuthorizationPolicies.BackOfficeAccess)]
-public class ContentLockHub : Hub<IContentLockHubEvents>
+public partial class ContentLockHub : Hub<IContentLockHubEvents>
 {
     private readonly IContentLockService _contentLockService;
     private readonly IOptionsMonitor<ContentLockOptions> _options;
@@ -76,6 +76,8 @@ public class ContentLockHub : Hub<IContentLockHubEvents>
             // If this user was in an active call, notify the peer and clean up
             await CleanUpCallOnDisconnectAsync(currentUserKey.Value);
         }
+
+        await CleanUpAutoLocksOnDisconnectAsync(currentUserKey, this.Context.ConnectionId);
 
         // Removes the user who is disconnecting
         await RemoveUserFromListOfConnectedUsersAsync();

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 - **Intuitive Lock/Unlock Actions:**  
   - Lock or unlock content nodes directly from the node actions (top right) or the tree view.
+
+- **Auto Lock (opt-in):**  
+  - Automatically locks a node as soon as an editor changes it, releasing it on save, leaving the node, disconnect, or after a configurable inactivity timeout.
+  - Warns an editor (by name) if another user removes the lock while they are still editing.
   
 - **Comprehensive Audit Trail:**  
   - Every lock and unlock action is logged in the node history for complete traceability.
@@ -42,6 +46,9 @@ Content Lock has the following options available to configure.
 | Setting | Description | Default Value |
 | -- | -- | -- |
 | SignalRClientLogLevel | The SignalR log level for browser console output. One of: `Trace`, `Debug`, `Information`/`Info`, `Warning`/`Warn`, `Error`, `Critical`, `None` | `"Info"` |
+| AutoLock.Enable | Automatically lock a node when an editor first changes it (released on save/leave/disconnect/inactivity). Reactive — no restart needed | `false` |
+| AutoLock.InactivityTimeoutSeconds | Seconds of editing inactivity after which an auto-lock is released. Resets on each edit | `300` |
+| AutoLock.HeartbeatSeconds | How often the browser refreshes its auto-lock while editing. Should be less than the inactivity timeout | `60` |
 | OnlineUsers.Enable | Displays a header app showing the number of active backoffice users | `true` |
 | OnlineUsers.Sounds.Enable | Play audio notifications when a user logs in or out of the backoffice | `true` |
 | OnlineUsers.Sounds.LoginSound | Path to the audio file played when a user logs in | `"/App_Plugins/ContentLock/sounds/login.mp3"` |
@@ -59,6 +66,11 @@ Content Lock has the following options available to configure.
 ...
 "ContentLock": {
   "SignalRClientLogLevel": "Info",
+  "AutoLock": {
+    "Enable": false,
+    "InactivityTimeoutSeconds": 300,
+    "HeartbeatSeconds": 60
+  },
   "OnlineUsers": {
     "Enable": true,
     "Sounds": {
@@ -88,6 +100,9 @@ Content Lock has the following options available to configure.
 ### Environment Variables
 ```
 ContentLock__SignalRClientLogLevel=Info
+ContentLock__AutoLock__Enable=false
+ContentLock__AutoLock__InactivityTimeoutSeconds=300
+ContentLock__AutoLock__HeartbeatSeconds=60
 ContentLock__OnlineUsers__Enable=true
 ContentLock__OnlineUsers__Sounds__Enable=true
 ContentLock__OnlineUsers__Sounds__LoginSound=https://some-snazzy-sound.com/sfx-login.mp3

--- a/appsettings-schema.umbraco.community.contentlock.json
+++ b/appsettings-schema.umbraco.community.contentlock.json
@@ -57,6 +57,29 @@
             "None"
           ]
         },
+        "AutoLock": {
+          "description": "Settings for automatically locking a node while a user is editing it.",
+          "type": "object",
+          "properties": {
+            "Enable": {
+              "type": "boolean",
+              "description": "Enable or disable automatically locking a node when a user starts editing it. Reactively applied without restart.",
+              "default": false
+            },
+            "InactivityTimeoutSeconds": {
+              "type": "integer",
+              "description": "Seconds of editing inactivity after which an auto-lock is released.",
+              "default": 300,
+              "minimum": 10
+            },
+            "HeartbeatSeconds": {
+              "type": "integer",
+              "description": "How often (seconds) the client refreshes its auto-lock while editing. Should be less than InactivityTimeoutSeconds.",
+              "default": 60,
+              "minimum": 5
+            }
+          }
+        },
         "WebRTC": {
           "description": "Settings for the WebRTC audio calling feature between backoffice users.",
           "type": "object",

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig({
 					label: 'Features',
 					items: [
 						{ label: 'Content Locking', slug: 'features/content-locking' },
+						{ label: 'Auto Lock', slug: 'features/auto-lock' },
 						{ label: 'Dashboard', slug: 'features/dashboard' },
 						{ label: 'Online Users', slug: 'features/online-users' },
 						{ label: 'Audio Calling', slug: 'features/audio-calling', badge: { text: '17.1.0+', variant: 'default'} },
@@ -49,6 +50,7 @@ export default defineConfig({
 					label: 'Configuration',
 					items: [
 						{ label: 'Overview', slug: 'configuration/overview' },
+						{ label: 'Auto Lock', slug: 'configuration/auto-lock' },
 						{ label: 'Online Users', slug: 'configuration/online-users' },
 						{ label: 'Audio Calling', slug: 'configuration/audio-calling', badge: { text: '17.1.0+', variant: 'default'} },
 					],

--- a/docs/src/content/docs/configuration/auto-lock.md
+++ b/docs/src/content/docs/configuration/auto-lock.md
@@ -1,0 +1,70 @@
+---
+title: Auto Lock Configuration
+description: Enable and tune automatic content locking on edit.
+---
+
+The `AutoLock` configuration section controls whether nodes are automatically locked when an editor starts changing them, and how long an idle lock is kept before it is released. See the [Auto Lock feature](/features/auto-lock/) for an overview of the behaviour.
+
+Auto Lock is **disabled by default**.
+
+---
+
+## Configuration
+
+```json
+{
+  "ContentLock": {
+    "AutoLock": {
+      "Enable": true,
+      "InactivityTimeoutSeconds": 300,
+      "HeartbeatSeconds": 60
+    }
+  }
+}
+```
+
+---
+
+## Options
+
+### `AutoLock.Enable`
+
+**Type:** `bool` | **Default:** `false` | **Reactive:** ✅ Yes
+
+Turns automatic locking on or off. When `true`, a node is locked automatically as soon as an editor makes their first change, and released on save / leaving the node / disconnect / inactivity timeout.
+
+When `false` (the default), only the manual [Lock/Unlock actions](/features/content-locking/) are available.
+
+This setting is **reactively applied** via SignalR — no server restart needed.
+
+---
+
+### `AutoLock.InactivityTimeoutSeconds`
+
+**Type:** `int` | **Default:** `300` | **Reactive:** ✅ Yes
+
+Seconds of editing inactivity after which an auto-lock is released server-side. The countdown resets every time the editor makes a change, so an actively edited node stays locked. Defaults to 5 minutes.
+
+---
+
+### `AutoLock.HeartbeatSeconds`
+
+**Type:** `int` | **Default:** `60` | **Reactive:** ✅ Yes
+
+How often the editor's browser refreshes its auto-lock while editing, keeping the server-side inactivity timer alive. This **should be less than `InactivityTimeoutSeconds`** — otherwise an actively edited lock could expire between heartbeats. Defaults to 1 minute.
+
+---
+
+## Reactive Behaviour
+
+Like the other ContentLock options, `AutoLock` settings use `IOptionsMonitor<ContentLockOptions>` and are pushed to all connected clients via the `ReceiveLatestOptions` SignalR event when `appsettings.json` changes — no restart or page reload required.
+
+---
+
+## Environment Variables
+
+```
+ContentLock__AutoLock__Enable=true
+ContentLock__AutoLock__InactivityTimeoutSeconds=300
+ContentLock__AutoLock__HeartbeatSeconds=60
+```

--- a/docs/src/content/docs/configuration/overview.md
+++ b/docs/src/content/docs/configuration/overview.md
@@ -13,6 +13,11 @@ All ContentLock settings live under the `ContentLock` key in `appsettings.json`.
 {
   "ContentLock": {
     "SignalRClientLogLevel": "Info",
+    "AutoLock": {
+      "Enable": false,
+      "InactivityTimeoutSeconds": 300,
+      "HeartbeatSeconds": 60
+    },
     "OnlineUsers": {
       "Enable": true,
       "Sounds": {
@@ -49,6 +54,16 @@ All ContentLock settings live under the `ContentLock` key in `appsettings.json`.
 | Option | Type | Default | Reactive | Description |
 |---|---|---|---|---|
 | `SignalRClientLogLevel` | `string` | `"Info"` | ❌ No | Log level for the SignalR JavaScript client. Valid values: `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`, `None`. Requires a page reload to take effect. |
+
+---
+
+### AutoLock
+
+| Option | Type | Default | Reactive | Description |
+|---|---|---|---|---|
+| `AutoLock.Enable` | `bool` | `false` | ✅ Yes | Automatically lock a node when an editor first changes it, releasing it on save/leave/disconnect/inactivity. |
+| `AutoLock.InactivityTimeoutSeconds` | `int` | `300` | ✅ Yes | Seconds of editing inactivity after which an auto-lock is released. Resets on each edit. |
+| `AutoLock.HeartbeatSeconds` | `int` | `60` | ✅ Yes | How often the browser refreshes its auto-lock while editing. Should be less than `InactivityTimeoutSeconds`. |
 
 ---
 
@@ -111,6 +126,7 @@ All ContentLock settings live under the `ContentLock` key in `appsettings.json`.
 All options can also be set via environment variables using the standard .NET configuration provider format, replacing `:` with `__`:
 
 ```
+ContentLock__AutoLock__Enable=true
 ContentLock__OnlineUsers__Enable=false
 ContentLock__WebRTC__TurnServer__Provider=Cloudflare
 ContentLock__WebRTC__TurnServer__Cloudflare__KeyId=your-key-id
@@ -121,5 +137,6 @@ ContentLock__WebRTC__TurnServer__Cloudflare__ApiToken=your-api-token
 
 ## Related
 
+- [Auto Lock Configuration](/configuration/auto-lock/) — automatic locking on edit
 - [Online Users Configuration](/configuration/online-users/) — sounds deep-dive
 - [WebRTC Configuration](/configuration/webrtc/) — TURN server setup guide

--- a/docs/src/content/docs/features/auto-lock.mdx
+++ b/docs/src/content/docs/features/auto-lock.mdx
@@ -1,0 +1,52 @@
+---
+title: Auto Lock
+description: Automatically lock a node while an editor is making changes, and release it automatically.
+---
+
+Auto Lock removes the need to manually lock a node before editing. When enabled, a node is locked **automatically the moment an editor makes their first change**, and released again automatically when they save, leave, disconnect, or go idle.
+
+It is **opt-in** and disabled by default, so existing installs are unaffected until you turn it on.
+
+:::note[Requires]
+Auto Lock is available from **17.x** and is enabled via configuration — see [Auto Lock configuration](/configuration/auto-lock/).
+:::
+
+---
+
+## Lifecycle
+
+| When | What happens |
+|---|---|
+| Editor changes any property value | The node is **auto-locked** for that editor |
+| Editor saves | The lock is **released** (re-acquired automatically on the next change) |
+| Editor leaves the node | The lock is **released** |
+| Editor disconnects (closes the tab/browser, network drop) | The lock is **released** server-side |
+| Editor is idle for the configured timeout | The lock is **released** server-side |
+
+While an editor keeps making changes, the lock stays held — a small "heartbeat" keeps it alive, and the inactivity countdown resets on each edit.
+
+---
+
+## Coexistence with manual locking
+
+Auto Lock sits alongside the manual [Lock/Unlock actions](/features/content-locking/) — both can be used:
+
+- A node already **manually locked** is never auto-locked over, and is **never auto-released** by the leave / disconnect / inactivity logic. Manual locks always require an explicit unlock.
+- Auto-locks and manual locks are distinguished in the database (an `IsAutoLock` flag), so automatic cleanup only ever affects auto-locks.
+
+---
+
+## Notification when another user unlocks your node
+
+If you are editing a node held by an auto-lock and **another user removes that lock** (for example an administrator unlocking it from the [dashboard](/features/dashboard/)), you are shown a notification naming who unlocked it, so you know your changes are no longer protected.
+
+This does **not** fire for your own save, leaving the node, or the inactivity timeout — only when a *different* user removes the lock.
+
+---
+
+## How releasing works
+
+- **Leaving / saving** is detected in the browser and releases the lock immediately for a snappy experience.
+- **Disconnect** and **inactivity timeout** are enforced **server-side**, so a closed tab, a crash, or an editor who walked away will always have their lock cleaned up without anyone needing to act.
+
+See [Auto Lock configuration](/configuration/auto-lock/) to enable it and tune the timeout and heartbeat.

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -24,6 +24,10 @@ Editors lock a content node via the tree right-click menu or the top actions men
 - A visual lock icon appears on the node in the content tree.
 - A footer banner shows who holds the lock.
 
+### Auto Lock
+
+Optionally, ContentLock can lock a node **automatically** the moment an editor makes their first change — no manual lock needed. The lock is released automatically when they save, leave the node, disconnect, or go idle for a configurable timeout. If another user removes the lock while you're still editing, you're notified who did it. Auto Lock is opt-in (disabled by default) and coexists with manual locking. See [Auto Lock](/features/auto-lock/).
+
 ### Real-Time Lock State
 
 Lock and unlock events are broadcast to **all connected backoffice users** via SignalR the moment they happen — no page refresh needed. If you're looking at a node and another editor locks it, it becomes read-only **immediately**.

--- a/docs/src/content/docs/reference/localization.md
+++ b/docs/src/content/docs/reference/localization.md
@@ -52,7 +52,9 @@ export default {
         unlockedHeader: 'Content Unlocked',
         unlockedMessage: 'The document has been unlocked, to allow other users to edit.',
         bulkUnlockHeader: 'Content Unlocked',
-        bulkUnlockMessage: 'The selected content has been unlocked successfully'
+        bulkUnlockMessage: 'The selected content has been unlocked successfully',
+        unlockedByOtherHeader: 'Lock Removed',
+        unlockedByOtherMessage: '{0} has unlocked this page. Your changes are no longer protected.'
     },
     contentLockPermission: {
         group: 'Content Lock',
@@ -133,6 +135,8 @@ Toast notification messages.
 | `unlockedMessage` | `The document has been unlocked, to allow other users to edit.` |
 | `bulkUnlockHeader` | `Content Unlocked` |
 | `bulkUnlockMessage` | `The selected content has been unlocked successfully` |
+| `unlockedByOtherHeader` | `Lock Removed` |
+| `unlockedByOtherMessage` | `{0} has unlocked this page. Your changes are no longer protected.` |
 
 ### `contentLockPermission`
 

--- a/docs/src/content/docs/reference/signalr-events.md
+++ b/docs/src/content/docs/reference/signalr-events.md
@@ -15,7 +15,10 @@ ContentLock uses a SignalR hub (`ContentLockHub`) mounted at `/umbraco/ContentLo
 | `AddLockToClients` | When any editor locks a node | `ContentLockOverviewItem` — the new lock |
 | `RemoveLockToClients` | When a single node is unlocked | `Guid` — the content key of the unlocked node |
 | `RemoveLocksToClients` | When bulk unlock is performed | `Guid[]` — the content keys of unlocked nodes |
+| `ReceiveLockUnlockedByUser` | When a user explicitly unlocks a node (single or bulk), sent just before the removal | `contentKey: Guid`, `unlockedByName: string`, `unlockedByKey: Guid` |
 | `RemoveAllLocksToClients` | E2E test cleanup only | *(no payload)* — instructs all clients to clear all locks |
+
+`ReceiveLockUnlockedByUser` lets a client holding an [auto-lock](/features/auto-lock/) on the node warn the editor who removed it. Auto-lock acquire/release reuse `AddLockToClients` / `RemoveLockToClients`.
 
 ---
 
@@ -56,6 +59,20 @@ These events handle WebRTC signalling between peers (offer/answer/ICE) and call 
 | `CallNoAnswer` | Sent to the caller when the ring timeout expires | *(no payload)* |
 | `MissedCall` | Sent to the recipient when the ring timeout expires | `callerKey: Guid`, `callerName: string` |
 | `ConnectedUsersInCallUpdated` | Broadcast to all clients when call participants change | `Guid[]` — keys of users currently in a call |
+
+---
+
+## Auto Lock Hub Methods (client → server)
+
+When [Auto Lock](/features/auto-lock/) is enabled, the browser invokes these hub methods (these are calls *to* the server, not broadcast events):
+
+| Method | Purpose |
+|---|---|
+| `AcquireAutoLock(contentKey)` | Acquire an auto-lock on first edit (no-op if already locked or Auto Lock is disabled). |
+| `AutoLockHeartbeat(contentKey)` | Reset the server-side inactivity timer while the editor keeps changing the node. |
+| `ReleaseAutoLock(contentKey)` | Release the auto-lock on save or when leaving the node. |
+
+The server also releases auto-locks automatically on disconnect (`OnDisconnectedAsync`) and when the inactivity timer expires. Only auto-locks are affected — manual locks are left untouched.
 
 ---
 

--- a/docs/src/content/docs/reference/signalr-events.md
+++ b/docs/src/content/docs/reference/signalr-events.md
@@ -16,9 +16,10 @@ ContentLock uses a SignalR hub (`ContentLockHub`) mounted at `/umbraco/ContentLo
 | `RemoveLockToClients` | When a single node is unlocked | `Guid` — the content key of the unlocked node |
 | `RemoveLocksToClients` | When bulk unlock is performed | `Guid[]` — the content keys of unlocked nodes |
 | `ReceiveLockUnlockedByUser` | When a user explicitly unlocks a node (single or bulk), sent just before the removal | `contentKey: Guid`, `unlockedByName: string`, `unlockedByKey: Guid` |
+| `ReceiveSuggestReload` | When a **locked** node is saved (content actually changed), so other users viewing it are prompted to reload | `contentKey: Guid`, `changedByKey: Guid` |
 | `RemoveAllLocksToClients` | E2E test cleanup only | *(no payload)* — instructs all clients to clear all locks |
 
-`ReceiveLockUnlockedByUser` lets a client holding an [auto-lock](/features/auto-lock/) on the node warn the editor who removed it. Auto-lock acquire/release reuse `AddLockToClients` / `RemoveLockToClients`.
+`ReceiveLockUnlockedByUser` lets a client holding an [auto-lock](/features/auto-lock/) on the node warn the editor who removed it. `ReceiveSuggestReload` is sent from the `ContentSaved` notification handler (only when the saved node was locked) and the editor who made the change is excluded client-side. Auto-lock acquire/release reuse `AddLockToClients` / `RemoveLockToClients`.
 
 ---
 

--- a/umbraco-marketplace-readme.md
+++ b/umbraco-marketplace-readme.md
@@ -14,6 +14,9 @@
 ### Lock & Unlock Content
 Lock or unlock content nodes directly from the node actions menu (top right) or the tree view. Locked nodes are immediately read-only for all other editors — no accidental overwrites.
 
+### Auto Lock _(opt-in)_
+Optionally lock a node **automatically** the moment an editor changes it — no manual step. The lock is released automatically on save, when leaving the node, on disconnect, or after a configurable inactivity timeout. If another user removes the lock while you're editing, you're notified who did it. Disabled by default; coexists with manual locking.
+
 ### Real-Time Updates
 Lock state is broadcast instantly to all connected backoffice users via **SignalR**. When someone locks or unlocks a node, every editor sees it update in real time — no page refresh needed.
 
@@ -52,6 +55,8 @@ Most settings are **reactive** — changes apply instantly without an applicatio
 
 | Setting | Description | Default |
 | --- | --- | --- |
+| `AutoLock.Enable` | Automatically lock a node when an editor first changes it | `false` |
+| `AutoLock.InactivityTimeoutSeconds` | Seconds of inactivity before an auto-lock is released | `300` |
 | `OnlineUsers.Enable` | Show the online users count in the backoffice header | `true` |
 | `OnlineUsers.Sounds.Enable` | Play audio when editors join or leave | `true` |
 | `WebRTC.Enable` | Enable peer-to-peer audio calling | `true` |


### PR DESCRIPTION
Opt-in feature that locks a content node the moment an editor first changes it, and releases it on save, leaving the node, disconnect, or after a configurable inactivity timeout.

- AutoLock options (Enable, HeartbeatSeconds), reactive via IOptionsMonitor
- IsAutoLock column + migration so automatic cleanup only ever affects auto-locks, never manual locks
- SignalR hub: AcquireAutoLock/ReleaseAutoLock/AutoLockHeartbeat, per-connection disconnect cleanup, server-side inactivity timer
- Client workspace context: acquire on first edit, throttled heartbeat while editing, release on save/leave
- Warn (by name) when another user removes your auto-lock, via the existing notification system
- Docs, 8-language localizations, and appsettings JSON schema updated